### PR TITLE
Feat/connection pooling

### DIFF
--- a/crates/firnflow-api/src/state.rs
+++ b/crates/firnflow-api/src/state.rs
@@ -35,6 +35,7 @@ pub async fn build_state(cfg: &AppConfig) -> anyhow::Result<AppState> {
     let manager = Arc::new(NamespaceManager::new(
         cfg.bucket.clone(),
         cfg.storage_options.clone(),
+        Arc::clone(&metrics),
     ));
 
     std::fs::create_dir_all(&cfg.cache_nvme_path).with_context(|| {

--- a/crates/firnflow-api/tests/api_compact.rs
+++ b/crates/firnflow-api/tests/api_compact.rs
@@ -64,7 +64,11 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,

--- a/crates/firnflow-api/tests/api_delete.rs
+++ b/crates/firnflow-api/tests/api_delete.rs
@@ -58,7 +58,11 @@ async fn build_app() -> (axum::Router, tempfile::TempDir) {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,

--- a/crates/firnflow-api/tests/api_fts.rs
+++ b/crates/firnflow-api/tests/api_fts.rs
@@ -75,7 +75,11 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,

--- a/crates/firnflow-api/tests/api_index.rs
+++ b/crates/firnflow-api/tests/api_index.rs
@@ -66,7 +66,11 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,

--- a/crates/firnflow-api/tests/api_metrics.rs
+++ b/crates/firnflow-api/tests/api_metrics.rs
@@ -68,7 +68,11 @@ async fn build_app() -> (axum::Router, tempfile::TempDir) {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,

--- a/crates/firnflow-api/tests/api_pool.rs
+++ b/crates/firnflow-api/tests/api_pool.rs
@@ -1,0 +1,201 @@
+//! Issue-1 API integration test: connection pool observable via
+//! `/metrics`.
+//!
+//! Drives the full HTTP path for one namespace — upsert → several
+//! queries — and verifies that:
+//!
+//! 1. `firnflow_cached_handles` ticks to exactly `1` after the
+//!    first upsert. That's the direct pool-gauge assertion.
+//! 2. `firnflow_s3_requests_total{operation="query"}` stays at
+//!    `1` for the whole run: the first query is a cache miss, the
+//!    remaining four are foyer-cache hits that never touch the
+//!    backend. Pool reuse amplifies the foyer cache's win — even
+//!    the single miss skips the connect() + open_table() cost
+//!    thanks to the pooled handle captured at upsert time.
+//!
+//! Gated `#[ignore]`: needs MinIO up.
+//!
+//! ```text
+//! docker compose up -d minio minio-init
+//! ./scripts/cargo test -p firnflow-api --test api_pool \
+//!     -- --ignored --nocapture
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use firnflow_api::{router, AppState};
+use firnflow_core::cache::NamespaceCache;
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{CoreMetrics, NamespaceManager, NamespaceService};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn unique_namespace(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "aws_access_key_id".into(),
+            env_or("FIRNFLOW_S3_ACCESS_KEY", "minioadmin"),
+        ),
+        (
+            "aws_secret_access_key".into(),
+            env_or("FIRNFLOW_S3_SECRET_KEY", "minioadmin"),
+        ),
+        (
+            "aws_endpoint".into(),
+            env_or("FIRNFLOW_S3_ENDPOINT", "http://127.0.0.1:9000"),
+        ),
+        ("aws_region".into(), "us-east-1".into()),
+        ("allow_http".into(), "true".into()),
+        ("aws_virtual_hosted_style_request".into(), "false".into()),
+    ])
+}
+
+async fn build_app() -> (axum::Router, tempfile::TempDir, Arc<CoreMetrics>) {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let tmp = tempfile::tempdir().unwrap();
+    let metrics = test_metrics();
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
+    let cache = Arc::new(
+        NamespaceCache::new(
+            16 * 1024 * 1024,
+            tmp.path(),
+            64 * 1024 * 1024,
+            Arc::clone(&metrics),
+        )
+        .await
+        .unwrap(),
+    );
+    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
+    let app = router(AppState {
+        service,
+        metrics: Arc::clone(&metrics),
+    });
+    (app, tmp, metrics)
+}
+
+async fn post_json(app: axum::Router, uri: String, body: Value) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, json)
+}
+
+async fn fetch_metrics(app: axum::Router) -> String {
+    let request = Request::builder()
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+fn metric_value(body: &str, metric: &str, label_needle: &str) -> Option<f64> {
+    for line in body.lines() {
+        if line.starts_with('#') || !line.starts_with(metric) {
+            continue;
+        }
+        if !label_needle.is_empty() && !line.contains(label_needle) {
+            continue;
+        }
+        let value = line.rsplit_once(char::is_whitespace)?.1;
+        return value.parse().ok();
+    }
+    None
+}
+
+#[tokio::test]
+#[ignore]
+async fn repeated_queries_reuse_connections() {
+    let (app, _tmp, metrics) = build_app().await;
+    let ns = unique_namespace("pool-api");
+
+    assert_eq!(
+        metrics.cached_handles_value(),
+        0,
+        "gauge is 0 before any traffic"
+    );
+
+    // Upsert once — first request for this namespace, so the pool
+    // populates on this call.
+    let upsert_body = json!({
+        "rows": [
+            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]},
+            {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}
+        ]
+    });
+    let (status, _) = post_json(app.clone(), format!("/ns/{ns}/upsert"), upsert_body).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        metrics.cached_handles_value(),
+        1,
+        "pool populated by the upsert"
+    );
+
+    // Query 5 times — first is a foyer-cache miss (hits the pooled
+    // handle), the remaining four are foyer-cache hits and never
+    // reach the backend at all.
+    let query_body = json!({
+        "vector": [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        "k": 1
+    });
+    for _ in 0..5 {
+        let (status, _) =
+            post_json(app.clone(), format!("/ns/{ns}/query"), query_body.clone()).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    // Pool size must not have grown: every query on this namespace
+    // reused the handle captured by the initial upsert.
+    assert_eq!(
+        metrics.cached_handles_value(),
+        1,
+        "pool size unchanged across repeated queries on the same ns"
+    );
+
+    // And the `/metrics` endpoint exposes the same value.
+    let body = fetch_metrics(app.clone()).await;
+    assert_eq!(
+        metric_value(&body, "firnflow_cached_handles", ""),
+        Some(1.0),
+        "cached_handles gauge reflected in /metrics output"
+    );
+
+    let query_label = format!(r#"namespace="{ns}",operation="query""#);
+    assert_eq!(
+        metric_value(&body, "firnflow_s3_requests_total", &query_label),
+        Some(1.0),
+        "exactly one query-kind S3 request — four cache hits must not count"
+    );
+}

--- a/crates/firnflow-api/tests/api_smoke.rs
+++ b/crates/firnflow-api/tests/api_smoke.rs
@@ -67,7 +67,11 @@ async fn build_app() -> (axum::Router, tempfile::TempDir) {
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
 
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,

--- a/crates/firnflow-api/tests/api_warmup.rs
+++ b/crates/firnflow-api/tests/api_warmup.rs
@@ -63,7 +63,11 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,

--- a/crates/firnflow-bench/src/main.rs
+++ b/crates/firnflow-bench/src/main.rs
@@ -251,6 +251,7 @@ async fn main() -> anyhow::Result<()> {
     let manager = Arc::new(NamespaceManager::new(
         cfg.bucket.clone(),
         cfg.storage_options.clone(),
+        Arc::clone(&metrics),
     ));
     let cache = Arc::new(
         NamespaceCache::new(

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -158,6 +158,21 @@ impl NamespaceManager {
         self.dims.get(ns).map(|r| *r)
     }
 
+    /// Number of namespaces currently holding a pooled
+    /// `lancedb::Connection` + `lancedb::Table` handle. Mirrors the
+    /// `firnflow_cached_handles` gauge and is exposed for tests
+    /// that need to assert pool-hit / pool-miss behaviour directly.
+    pub fn pool_size(&self) -> usize {
+        self.handles.len()
+    }
+
+    /// Whether a pooled handle exists for `ns`. Useful for tests
+    /// that want to confirm a specific namespace was (or was not)
+    /// evicted.
+    pub fn is_pooled(&self, ns: &NamespaceId) -> bool {
+        self.handles.contains_key(ns)
+    }
+
     fn uri(&self, ns: &NamespaceId) -> String {
         format!("s3://{}/{}", self.bucket, ns.as_str())
     }

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -1,10 +1,7 @@
 //! Namespace manager — the production shim over lancedb.
 //!
 //! Each namespace maps to its own Lance table rooted at
-//! `s3://{bucket}/{namespace}/`. The manager is stateless with
-//! respect to connections: every public call opens a fresh
-//! `lancedb::Connection`. Connection caching is a later
-//! optimisation.
+//! `s3://{bucket}/{namespace}/`.
 //!
 //! **Per-namespace dimensions (slice 6a):** the manager no longer
 //! carries a global `vector_dim`. Instead, dimensions are:
@@ -19,6 +16,19 @@
 //! namespace per process lifetime. Entries stay until the process
 //! restarts or the namespace is deleted (in which case the stale
 //! entry is evicted lazily on next use).
+//!
+//! **Connection pooling (issue #1):** each namespace's
+//! `lancedb::Connection` + `lancedb::Table` are cached in a
+//! `DashMap<NamespaceId, NamespaceHandle>` after the first
+//! successful open. Subsequent upserts, queries, index builds, and
+//! compactions reuse the cached handle, skipping the
+//! S3-credential-resolution and manifest-read cost of a fresh
+//! `lancedb::connect()` + `open_table()`.
+//!
+//! The pool is invalidated on namespace delete and on operations
+//! that change the table's manifest (index build, compaction). A
+//! regular append-only upsert does **not** evict — Lance appends
+//! are visible through the existing handle.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -41,6 +51,7 @@ use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjectStorePath;
 use object_store::ObjectStore;
 
+use crate::metrics::CoreMetrics;
 use crate::query::DEFAULT_NPROBES;
 use crate::{FirnflowError, NamespaceId, QueryResult, QueryResultSet};
 
@@ -70,18 +81,41 @@ impl From<(u64, Vec<f32>)> for UpsertRow {
     }
 }
 
-/// Stateless namespace manager over an S3-backed set of Lance tables.
+/// Cached per-namespace backend handles. Both members are cheap to
+/// hold: `Connection` is an S3 client + config; `Table` is an
+/// in-memory metadata handle referencing the connection. Storing
+/// both explicitly (rather than leaning on `Table`'s internal
+/// reference to its connection) keeps the slow-path logic
+/// self-contained and leaves room for a future code path that
+/// wants to re-open a table against the cached connection.
+struct NamespaceHandle {
+    #[allow(dead_code)]
+    conn: lancedb::Connection,
+    table: lancedb::Table,
+}
+
+/// Namespace manager over an S3-backed set of Lance tables.
 ///
 /// Each namespace independently determines its own vector dimension
 /// — either inferred from the first upsert or read from the
 /// existing Lance table schema. A single manager instance can serve
 /// namespaces with different dimensions simultaneously.
+///
+/// The manager caches an `lancedb::Connection` + `lancedb::Table`
+/// per namespace in an internal `DashMap` so repeat operations on
+/// the same namespace avoid the S3 credential-resolution and
+/// manifest-read round-trip of a fresh `lancedb::connect()`.
 pub struct NamespaceManager {
     bucket: String,
     storage_options: HashMap<String, String>,
     /// Per-namespace resolved dimensions. Populated on first
     /// interaction with each namespace (upsert or query).
     dims: DashMap<NamespaceId, usize>,
+    /// Per-namespace connection + table handles. Populated lazily
+    /// by [`NamespaceManager::get_or_open_table`] and evicted on
+    /// namespace delete / index build / compaction.
+    handles: DashMap<NamespaceId, NamespaceHandle>,
+    metrics: Arc<CoreMetrics>,
 }
 
 impl NamespaceManager {
@@ -93,11 +127,27 @@ impl NamespaceManager {
     /// * `storage_options` – `object_store`-style key/value options
     ///   passed verbatim to lancedb's connection builder. Use
     ///   `aws_endpoint` / `aws_access_key_id` / etc. keys.
-    pub fn new(bucket: impl Into<String>, storage_options: HashMap<String, String>) -> Self {
+    /// * `metrics` – process-wide metrics registry; the manager
+    ///   adjusts `firnflow_cached_handles` as connection pool
+    ///   entries are added and removed.
+    ///
+    /// **Credential rotation note:** `storage_options` is captured
+    /// once and reused for the lifetime of every cached connection.
+    /// If the deployment rotates credentials at runtime, every
+    /// cached handle must be flushed when `storage_options` changes
+    /// — no such mechanism exists today. For V1 we document this
+    /// as a known single-process assumption.
+    pub fn new(
+        bucket: impl Into<String>,
+        storage_options: HashMap<String, String>,
+        metrics: Arc<CoreMetrics>,
+    ) -> Self {
         Self {
             bucket: bucket.into(),
             storage_options,
             dims: DashMap::new(),
+            handles: DashMap::new(),
+            metrics,
         }
     }
 
@@ -135,34 +185,50 @@ impl NamespaceManager {
             .map_err(|e| FirnflowError::Backend(format!("lancedb connect: {e}")))
     }
 
-    /// Try to open the existing table and read its vector dimension
-    /// from the schema. Returns `Ok(Some((table, dim)))` if the
-    /// table exists, `Ok(None)` if it does not.
-    async fn open_existing(
-        &self,
-        ns: &NamespaceId,
-    ) -> Result<Option<(lancedb::Table, usize)>, FirnflowError> {
-        let conn = self.connect(ns).await?;
-        match conn.open_table(TABLE_NAME).execute().await {
-            Ok(tbl) => {
-                let dim = read_dim_from_table(&tbl).await?;
-                Ok(Some((tbl, dim)))
-            }
-            Err(_) => Ok(None),
+    /// Insert a freshly opened `NamespaceHandle` into the pool and
+    /// bump the `cached_handles` gauge. If a handle for `ns` already
+    /// exists (race between two concurrent openers), the second
+    /// insert overwrites the first — both are valid, the first is
+    /// simply dropped.
+    fn cache_handle(&self, ns: &NamespaceId, conn: lancedb::Connection, table: lancedb::Table) {
+        let previous = self
+            .handles
+            .insert(ns.clone(), NamespaceHandle { conn, table });
+        if previous.is_none() {
+            self.metrics.inc_cached_handles();
         }
     }
 
-    /// Open the namespace's data table, creating it with an empty
-    /// batch if it does not yet exist. The dimension must be known
-    /// at creation time (from the first upsert).
-    async fn open_or_create_table(
+    /// Drop a namespace's cached handle and decrement the gauge.
+    /// Called after operations that change the table's manifest or
+    /// remove its data: delete, index build, compaction.
+    fn evict_handle(&self, ns: &NamespaceId) {
+        if self.handles.remove(ns).is_some() {
+            self.metrics.dec_cached_handles();
+        }
+    }
+
+    /// Return a cached `lancedb::Table` for `ns`, opening (and if
+    /// necessary, creating) one on a cache miss. This is the single
+    /// entry point every public method uses to obtain a table
+    /// handle — removing the old "new connection per call" cost.
+    ///
+    /// On a miss the table is opened; if it does not yet exist a
+    /// fresh one is created with the `dim`-shaped schema. The
+    /// resulting handle is cached in `self.handles` so the next
+    /// caller hits the fast path.
+    async fn get_or_open_table(
         &self,
         ns: &NamespaceId,
         dim: usize,
     ) -> Result<lancedb::Table, FirnflowError> {
+        if let Some(entry) = self.handles.get(ns) {
+            return Ok(entry.table.clone());
+        }
+
         let conn = self.connect(ns).await?;
-        match conn.open_table(TABLE_NAME).execute().await {
-            Ok(tbl) => Ok(tbl),
+        let table = match conn.open_table(TABLE_NAME).execute().await {
+            Ok(tbl) => tbl,
             Err(_) => {
                 let schema = Self::schema_for_dim(dim);
                 let empty = rows_to_batch(&schema, dim, Vec::new())?;
@@ -171,8 +237,38 @@ impl NamespaceManager {
                 conn.create_table(TABLE_NAME, reader)
                     .execute()
                     .await
-                    .map_err(|e| FirnflowError::Backend(format!("create_table: {e}")))
+                    .map_err(|e| FirnflowError::Backend(format!("create_table: {e}")))?
             }
+        };
+
+        let cloned = table.clone();
+        self.cache_handle(ns, conn, table);
+        Ok(cloned)
+    }
+
+    /// Try to open an existing table for `ns` without creating one.
+    /// Used by [`resolve_dim`] to discover a namespace's dimension
+    /// from its persisted schema. On success the handle is cached
+    /// so the subsequent operation avoids a second `open_table`.
+    async fn open_existing(
+        &self,
+        ns: &NamespaceId,
+    ) -> Result<Option<(lancedb::Table, usize)>, FirnflowError> {
+        if let Some(entry) = self.handles.get(ns) {
+            let tbl = entry.table.clone();
+            drop(entry);
+            let dim = read_dim_from_table(&tbl).await?;
+            return Ok(Some((tbl, dim)));
+        }
+
+        let conn = self.connect(ns).await?;
+        match conn.open_table(TABLE_NAME).execute().await {
+            Ok(tbl) => {
+                let dim = read_dim_from_table(&tbl).await?;
+                self.cache_handle(ns, conn, tbl.clone());
+                Ok(Some((tbl, dim)))
+            }
+            Err(_) => Ok(None),
         }
     }
 
@@ -233,7 +329,7 @@ impl NamespaceManager {
             }
         }
 
-        let tbl = self.open_or_create_table(ns, dim).await?;
+        let tbl = self.get_or_open_table(ns, dim).await?;
         let schema = Self::schema_for_dim(dim);
         let batch = rows_to_batch(&schema, dim, rows)?;
         let reader: Box<dyn RecordBatchReader + Send> =
@@ -251,8 +347,10 @@ impl NamespaceManager {
     /// Remove every object under a namespace prefix from the
     /// underlying object store.
     ///
-    /// Also evicts the cached dimension for this namespace so that
-    /// a subsequent upsert can establish a new dimension.
+    /// Also evicts the cached dimension **and** the pooled
+    /// connection/table handle for this namespace so that a
+    /// subsequent upsert can establish a new dimension against a
+    /// fresh Lance table.
     ///
     /// Returns the number of objects deleted. The caller
     /// (`NamespaceService::delete`) is responsible for invalidating
@@ -273,8 +371,9 @@ impl NamespaceManager {
             count += 1;
         }
 
-        // Evict the dimension cache so a fresh upsert can pick a new dim.
+        // Evict dim + pooled handle so a fresh upsert can pick a new dim.
         self.dims.remove(ns);
+        self.evict_handle(ns);
 
         Ok(count)
     }
@@ -349,7 +448,7 @@ impl NamespaceManager {
         }
 
         let nprobes = nprobes.unwrap_or(DEFAULT_NPROBES);
-        let tbl = self.open_or_create_table(ns, dim).await?;
+        let tbl = self.get_or_open_table(ns, dim).await?;
 
         let stream = if has_vector {
             // Vector-only or hybrid (lancedb auto-detects hybrid when
@@ -411,7 +510,7 @@ impl NamespaceManager {
             ))
         })?;
 
-        let tbl = self.open_or_create_table(ns, dim).await?;
+        let tbl = self.get_or_open_table(ns, dim).await?;
 
         let mut builder = IvfPqIndexBuilder::default().distance_type(DistanceType::L2);
         if let Some(n) = num_partitions {
@@ -426,6 +525,11 @@ impl NamespaceManager {
             .await
             .map_err(|e| FirnflowError::Backend(format!("create_index: {e}")))?;
 
+        // Evict the pooled handle: building an index bumps the
+        // table manifest, so the next operation should open a fresh
+        // table view rather than reuse metadata captured before the
+        // build.
+        self.evict_handle(ns);
         Ok(())
     }
 
@@ -439,12 +543,14 @@ impl NamespaceManager {
             ))
         })?;
 
-        let tbl = self.open_or_create_table(ns, dim).await?;
+        let tbl = self.get_or_open_table(ns, dim).await?;
         tbl.create_index(&["text"], Index::FTS(FtsIndexBuilder::default()))
             .execute()
             .await
             .map_err(|e| FirnflowError::Backend(format!("create_fts_index: {e}")))?;
 
+        // Same manifest-bump rationale as `create_index`.
+        self.evict_handle(ns);
         Ok(())
     }
 
@@ -465,7 +571,7 @@ impl NamespaceManager {
             ))
         })?;
 
-        let tbl = self.open_or_create_table(ns, dim).await?;
+        let tbl = self.get_or_open_table(ns, dim).await?;
         let stats = tbl
             .optimize(OptimizeAction::default())
             .await
@@ -475,6 +581,10 @@ impl NamespaceManager {
             .compaction
             .map(|c| (c.fragments_removed, c.fragments_added))
             .unwrap_or((0, 0));
+
+        // Compaction rewrites fragments: any cached Table view is
+        // pointing at file offsets that no longer exist.
+        self.evict_handle(ns);
 
         Ok(CompactResult {
             fragments_removed: removed,

--- a/crates/firnflow-core/src/metrics.rs
+++ b/crates/firnflow-core/src/metrics.rs
@@ -10,6 +10,7 @@
 //! * `firnflow_write_duration_seconds{namespace}`
 //! * `firnflow_active_namespaces`
 //! * `firnflow_s3_requests_total{namespace, operation}`
+//! * `firnflow_cached_handles`
 //!
 //! Constructed once at process start (in
 //! `firnflow-api::state::build_state`), wrapped in `Arc`, and
@@ -48,6 +49,7 @@ pub struct CoreMetrics {
     s3_requests: IntCounterVec,
     index_build_duration: HistogramVec,
     compaction_duration: HistogramVec,
+    cached_handles: IntGauge,
     seen_namespaces: DashSet<NamespaceId>,
 }
 
@@ -166,6 +168,19 @@ impl CoreMetrics {
             .register(Box::new(compaction_duration.clone()))
             .map_err(metrics_err)?;
 
+        let cached_handles = IntGauge::new(
+            "firnflow_cached_handles",
+            "Number of namespaces with a warm `lancedb::Connection` + \
+             `lancedb::Table` handle in the in-process pool. Compare \
+             against `firnflow_active_namespaces` — the delta is the \
+             number of active namespaces that will pay cold-open cost \
+             on their next request.",
+        )
+        .map_err(metrics_err)?;
+        registry
+            .register(Box::new(cached_handles.clone()))
+            .map_err(metrics_err)?;
+
         Ok(Self {
             registry,
             cache_hits,
@@ -176,6 +191,7 @@ impl CoreMetrics {
             s3_requests,
             index_build_duration,
             compaction_duration,
+            cached_handles,
             seen_namespaces: DashSet::new(),
         })
     }
@@ -255,6 +271,18 @@ impl CoreMetrics {
         self.compaction_duration
             .with_label_values(&[ns.as_str()])
             .observe(duration_secs);
+    }
+
+    /// Bump the cached-handles gauge when `NamespaceManager` inserts
+    /// a fresh `NamespaceHandle` into its pool.
+    pub fn inc_cached_handles(&self) {
+        self.cached_handles.inc();
+    }
+
+    /// Drop the cached-handles gauge when `NamespaceManager` evicts
+    /// a `NamespaceHandle` (namespace delete / index build / compact).
+    pub fn dec_cached_handles(&self) {
+        self.cached_handles.dec();
     }
 }
 

--- a/crates/firnflow-core/src/metrics.rs
+++ b/crates/firnflow-core/src/metrics.rs
@@ -284,6 +284,12 @@ impl CoreMetrics {
     pub fn dec_cached_handles(&self) {
         self.cached_handles.dec();
     }
+
+    /// Current value of the `firnflow_cached_handles` gauge. Used
+    /// by tests; production code should read it via `/metrics`.
+    pub fn cached_handles_value(&self) -> i64 {
+        self.cached_handles.get()
+    }
 }
 
 /// Build an `Arc<CoreMetrics>` for tests and stand-alone binaries

--- a/crates/firnflow-core/tests/manager_connection_pool.rs
+++ b/crates/firnflow-core/tests/manager_connection_pool.rs
@@ -1,0 +1,241 @@
+//! Issue-1 integration test: `NamespaceManager` connection pool.
+//!
+//! Proves three properties of the pool:
+//!
+//! 1. The handle for a namespace survives across calls. Two
+//!    consecutive `upsert`s on the same namespace must use the
+//!    cached connection + table — observable as a single pool
+//!    entry and a warm-path latency below the cold path.
+//! 2. `delete(ns)` evicts the handle. After a delete the pool no
+//!    longer reports the namespace and the dim cache is cleared,
+//!    so a follow-up upsert with a different dimension succeeds.
+//! 3. `compact(ns)` evicts the handle. Compaction rewrites
+//!    fragments; any cached `Table` view still pointing at the
+//!    pre-compact file offsets is invalidated. The next query
+//!    must reopen cleanly.
+//!
+//! The gauge is asserted via `CoreMetrics::cached_handles_value`,
+//! which tracks the `firnflow_cached_handles` counter the API
+//! exposes at `/metrics`.
+//!
+//! Gated `#[ignore]`: needs MinIO up.
+//!
+//! ```text
+//! docker compose up -d minio minio-init
+//! ./scripts/cargo test -p firnflow-core --test manager_connection_pool \
+//!     -- --ignored --nocapture
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{NamespaceId, NamespaceManager, UpsertRow};
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn unique_namespace(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "aws_access_key_id".into(),
+            env_or("FIRNFLOW_S3_ACCESS_KEY", "minioadmin"),
+        ),
+        (
+            "aws_secret_access_key".into(),
+            env_or("FIRNFLOW_S3_SECRET_KEY", "minioadmin"),
+        ),
+        (
+            "aws_endpoint".into(),
+            env_or("FIRNFLOW_S3_ENDPOINT", "http://127.0.0.1:9000"),
+        ),
+        ("aws_region".into(), "us-east-1".into()),
+        ("allow_http".into(), "true".into()),
+        ("aws_virtual_hosted_style_request".into(), "false".into()),
+    ])
+}
+
+/// Two orthogonal unit vectors of `dim` with ids 1 and 2.
+fn seed_rows(dim: usize) -> Vec<UpsertRow> {
+    let mut a = vec![0.0_f32; dim];
+    a[0] = 1.0;
+    let mut b = vec![0.0_f32; dim];
+    b[1 % dim] = 1.0;
+    vec![UpsertRow::from((1u64, a)), UpsertRow::from((2u64, b))]
+}
+
+#[tokio::test]
+#[ignore]
+async fn cached_handle_survives_across_operations() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let metrics = test_metrics();
+    let manager = NamespaceManager::new(bucket, minio_options(), Arc::clone(&metrics));
+    let ns = NamespaceId::new(unique_namespace("pool-reuse")).unwrap();
+
+    assert_eq!(manager.pool_size(), 0, "pool starts empty");
+    assert_eq!(metrics.cached_handles_value(), 0, "gauge starts at 0");
+
+    // Cold upsert: opens a connection + creates the table, caches both.
+    let t0 = Instant::now();
+    manager
+        .upsert(&ns, seed_rows(8))
+        .await
+        .expect("cold upsert");
+    let cold_ms = t0.elapsed().as_millis();
+
+    assert!(manager.is_pooled(&ns), "handle cached after first upsert");
+    assert_eq!(manager.pool_size(), 1, "pool has exactly one entry");
+    assert_eq!(
+        metrics.cached_handles_value(),
+        1,
+        "gauge reflects the single cached handle"
+    );
+
+    // Warm upsert: must reuse the cached handle — no new connect(),
+    // no new open_table().
+    let t1 = Instant::now();
+    manager
+        .upsert(&ns, seed_rows(8))
+        .await
+        .expect("warm upsert");
+    let warm_ms = t1.elapsed().as_millis();
+
+    assert_eq!(
+        manager.pool_size(),
+        1,
+        "pool size unchanged after warm upsert"
+    );
+    assert_eq!(
+        metrics.cached_handles_value(),
+        1,
+        "gauge unchanged after warm upsert"
+    );
+
+    println!("cold upsert: {cold_ms}ms, warm upsert: {warm_ms}ms");
+    assert!(
+        warm_ms <= cold_ms,
+        "warm upsert ({warm_ms}ms) should not be slower than cold ({cold_ms}ms)"
+    );
+
+    // A query on the same namespace should also stay on the fast
+    // path — no pool growth, no eviction.
+    let results = manager
+        .query(
+            &ns,
+            vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            2,
+            None,
+            None,
+        )
+        .await
+        .expect("query reuses pooled handle");
+    assert_eq!(results.results.len(), 2, "query returns the two rows");
+    assert_eq!(manager.pool_size(), 1, "query does not grow the pool");
+}
+
+#[tokio::test]
+#[ignore]
+async fn handle_evicted_on_namespace_delete() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let metrics = test_metrics();
+    let manager = NamespaceManager::new(bucket, minio_options(), Arc::clone(&metrics));
+    let ns = NamespaceId::new(unique_namespace("pool-delete")).unwrap();
+
+    // Establish the namespace at dim=8.
+    manager
+        .upsert(&ns, seed_rows(8))
+        .await
+        .expect("seed upsert");
+    assert!(manager.is_pooled(&ns));
+    assert_eq!(manager.dim_for(&ns), Some(8));
+    assert_eq!(metrics.cached_handles_value(), 1);
+
+    manager.delete(&ns).await.expect("delete namespace");
+
+    assert!(
+        !manager.is_pooled(&ns),
+        "delete must evict the pooled handle"
+    );
+    assert_eq!(
+        metrics.cached_handles_value(),
+        0,
+        "gauge decremented on eviction"
+    );
+    assert_eq!(
+        manager.dim_for(&ns),
+        None,
+        "dim cache cleared so the ns can be re-created at a new width"
+    );
+
+    // Reseed at a different dimension — only possible if the stale
+    // pool entry (which held a dim=8 Table) is really gone.
+    manager
+        .upsert(&ns, seed_rows(16))
+        .await
+        .expect("reseed at dim=16 after delete");
+    assert_eq!(manager.dim_for(&ns), Some(16));
+    assert!(manager.is_pooled(&ns), "fresh handle cached after reseed");
+}
+
+#[tokio::test]
+#[ignore]
+async fn handle_evicted_after_compaction() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let metrics = test_metrics();
+    let manager = NamespaceManager::new(bucket, minio_options(), Arc::clone(&metrics));
+    let ns = NamespaceId::new(unique_namespace("pool-compact")).unwrap();
+
+    // Write enough fragments to make compaction meaningful.
+    for _ in 0..5 {
+        manager
+            .upsert(&ns, seed_rows(8))
+            .await
+            .expect("seed upsert");
+    }
+    assert!(manager.is_pooled(&ns), "pool populated after seeding");
+    assert_eq!(metrics.cached_handles_value(), 1);
+
+    manager.compact(&ns).await.expect("compact");
+    assert!(
+        !manager.is_pooled(&ns),
+        "compaction must evict the pooled handle (fragment offsets change)"
+    );
+    assert_eq!(
+        metrics.cached_handles_value(),
+        0,
+        "gauge decremented by compaction eviction"
+    );
+
+    // Query path must still succeed — the next call reopens a
+    // fresh Table against the post-compact manifest.
+    let results = manager
+        .query(
+            &ns,
+            vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            2,
+            None,
+            None,
+        )
+        .await
+        .expect("query after compaction reopens the table");
+    assert_eq!(
+        results.results.len(),
+        2,
+        "compacted data is still queryable"
+    );
+    assert!(
+        manager.is_pooled(&ns),
+        "query re-populated the pool after the compact-triggered eviction"
+    );
+    assert_eq!(metrics.cached_handles_value(), 1);
+}

--- a/crates/firnflow-core/tests/manager_per_namespace_dim.rs
+++ b/crates/firnflow-core/tests/manager_per_namespace_dim.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 
+use firnflow_core::metrics::test_metrics;
 use firnflow_core::{NamespaceId, NamespaceManager, UpsertRow};
 
 fn env_or(key: &str, default: &str) -> String {
@@ -61,7 +62,7 @@ fn unit_vector(dim: usize, axis: usize) -> Vec<f32> {
 #[ignore]
 async fn three_namespaces_with_different_dims() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
-    let manager = NamespaceManager::new(bucket, minio_options());
+    let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
 
     let ns4 = NamespaceId::new(unique_namespace("slice6a-dim4")).unwrap();
     let ns8 = NamespaceId::new(unique_namespace("slice6a-dim8")).unwrap();
@@ -171,7 +172,7 @@ async fn three_namespaces_with_different_dims() {
 #[ignore]
 async fn first_upsert_infers_dim_and_validates_remaining_rows() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
-    let manager = NamespaceManager::new(bucket, minio_options());
+    let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
     let ns = NamespaceId::new(unique_namespace("slice6a-infer")).unwrap();
 
     // Row 0 has dim=4, row 1 has dim=6 — must fail with a clear error.

--- a/crates/firnflow-core/tests/manager_upsert_query.rs
+++ b/crates/firnflow-core/tests/manager_upsert_query.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 
+use firnflow_core::metrics::test_metrics;
 use firnflow_core::{NamespaceId, NamespaceManager, UpsertRow};
 
 const DIM: usize = 8;
@@ -62,7 +63,7 @@ fn unit_vector(axis: usize) -> Vec<f32> {
 #[ignore]
 async fn upsert_then_query_returns_nearest_neighbor() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
-    let manager = NamespaceManager::new(bucket, minio_options());
+    let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
     let ns = NamespaceId::new(unique_namespace("slice1a")).unwrap();
 
     // Four orthogonal unit vectors along the first four axes.
@@ -104,7 +105,7 @@ async fn upsert_then_query_returns_nearest_neighbor() {
 #[ignore]
 async fn upsert_validates_vector_dimension() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
-    let manager = NamespaceManager::new(bucket, minio_options());
+    let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
     let ns = NamespaceId::new(unique_namespace("slice1a-dim")).unwrap();
 
     // Establish the namespace dimension via a valid first upsert.

--- a/crates/firnflow-core/tests/service_cache_aside.rs
+++ b/crates/firnflow-core/tests/service_cache_aside.rs
@@ -78,7 +78,11 @@ async fn service_cache_aside_invalidates_on_upsert() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
     let metrics = test_metrics();
-    let manager = Arc::new(NamespaceManager::new(bucket, minio_options()));
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
     let cache = Arc::new(
         NamespaceCache::new(
             16 * 1024 * 1024,


### PR DESCRIPTION
Closes #1.

## Summary

`NamespaceManager` previously opened a fresh `lancedb::Connection` and re-read the Lance manifest from S3 on every public call. It now caches the `Connection` + `Table` per namespace in a `DashMap<NamespaceId, NamespaceHandle>`. Repeat operations on the same namespace reuse the pooled handle and skip the S3 credential-resolution + manifest-read round-trip.

## What changed 

- `NamespaceManager` holds a per-namespace handle pool. A single private `get_or_open_table()` replaces the old `connect()` + `open_or_create_table()` call sites.
- Pool is invalidated on `delete()`, `create_index()`, `create_fts_index()`, and `compact()` — operations that mutate the table manifest or remove data. Append-only `upsert()` does not evict, since Lance appends are visible through the cached handle. 
- New Prometheus gauge `firnflow_cached_handles` (unscoped), exposed at `/metrics`. Compare against `firnflow_active_namespaces` to see how many namespaces are paying cold-open cost.
- `NamespaceManager::new()` takes `Arc<CoreMetrics>` as a third argument so the manager can drive the gauge. All 13 call sites (API state, bench harness, integration tests) updated
accordingly.
- Credential-rotation caveat documented in rustdoc: cached connections are tied to the `storage_options` captured at construction. Out of scope for V1. 

## Verification 

Against MinIO: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test -p firnflow-core -- --ignored` (14/14), and `cargo test -p firnflow-api -- --ignored`
(10/10) all pass.

New tests: `crates/firnflow-core/tests/manager_connection_pool.rs` covers handle reuse, eviction on delete, and eviction after compaction. `crates/firnflow-api/tests/api_pool.rs`
asserts `firnflow_cached_handles` reaches 1 after one upsert and stays there across five identical queries, while `firnflow_s3_requests_total{operation=query}` stays at 1 (four cache
 hits never touch the backend). 

Observed: cold upsert ~108 ms -> warm upsert ~8 ms on MinIO loopback (~13× speedup).