### PR TITLE
docs: document firnflow_cached_handles gauge and connection pool

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -68,7 +68,7 @@
       <li><strong>Hash the query.</strong> The full <code>QueryRequest</code> (vector, k, nprobes, text) is serialised with bincode and hashed with xxh3 to produce a deterministic <code>QueryHash</code>.</li>
       <li><strong>Build the cache key.</strong> The key is a tuple of <code>(namespace, generation, query_hash)</code>. The generation counter ensures stale results are never returned after a write.</li>
       <li><strong>Check foyer.</strong> The HybridCache checks RAM first, then NVMe. On a hit, the serialised result is returned and a <code>cache_hits_total</code> metric is recorded.</li>
-      <li><strong>On miss: query S3.</strong> LanceDB runs the query against the Lance table on S3 (vector nearest-neighbour, BM25 FTS, or hybrid). The result is serialised with bincode and stored in foyer. A <code>cache_misses_total</code> and <code>s3_requests_total</code> metric are recorded.</li>
+      <li><strong>On miss: query S3.</strong> LanceDB runs the query against the Lance table on S3 (vector nearest-neighbour, BM25 FTS, or hybrid) using the namespace's pooled <code>Connection</code> and <code>Table</code> handle &mdash; the first request for a namespace opens and caches the handle, every subsequent request skips the credential-resolution and manifest-read round-trips. The result is serialised with bincode and stored in foyer. A <code>cache_misses_total</code> and <code>s3_requests_total</code> metric are recorded.</li>
       <li><strong>Return the result.</strong> The query duration (cache hit or miss) is recorded in the <code>query_duration_seconds</code> histogram.</li>
     </ol>
 
@@ -103,6 +103,19 @@
         <tr><td>Trade-off</td><td>Stale-generation entries remain in the cache until evicted by foyer. Under write-heavy workloads, the NVMe tier may hold unreachable entries temporarily.</td></tr>
       </tbody>
     </table>
+
+    <h2>Connection pool</h2>
+    <p>The namespace manager caches a <code>lancedb::Connection</code> and <code>Table</code> handle per namespace after the first open. Without the pool, every upsert and every cache-miss query would re-run S3 credential resolution and re-read the Lance table manifest from S3; with the pool, those costs are paid once per namespace per process lifetime.</p>
+
+    <p>The pool is invalidated on operations that change the table's manifest or remove its data:</p>
+    <ul>
+      <li><code>DELETE /ns/{ns}</code> &mdash; all objects gone, handle evicted</li>
+      <li><code>POST /ns/{ns}/index</code> and <code>/fts-index</code> &mdash; manifest bumped, handle evicted</li>
+      <li><code>POST /ns/{ns}/compact</code> &mdash; fragment offsets change, handle evicted</li>
+    </ul>
+    <p>Ordinary upserts do <strong>not</strong> evict the handle. Lance appends are visible through the existing handle, so there is no need to reopen the table on every write.</p>
+
+    <p>Pool occupancy is exposed as the <code>firnflow_cached_handles</code> gauge at <code>/metrics</code>. Compare it against <code>firnflow_active_namespaces</code> to see how many namespaces are currently paying the cold-open cost.</p>
 
     <h2>Namespace isolation</h2>
     <p>Each namespace is a fully isolated unit:</p>

--- a/docs/monitoring.html
+++ b/docs/monitoring.html
@@ -126,6 +126,12 @@ scrape_configs:
           <td><em>none</em></td>
           <td>Number of distinct namespaces that have been accessed since startup.</td>
         </tr>
+        <tr>
+          <td><code>firnflow_cached_handles</code></td>
+          <td>Gauge</td>
+          <td><em>none</em></td>
+          <td>Number of namespaces holding a warm <code>lancedb::Connection</code> and <code>Table</code> handle in the in-process pool. The delta against <code>firnflow_active_namespaces</code> is the number of active namespaces that will pay the cold-open cost on their next request.</td>
+        </tr>
       </tbody>
     </table>
 
@@ -163,6 +169,10 @@ histogram_quantile(0.99, rate(firnflow_query_duration_seconds_bucket[5m]))</code
 
     <h3>Write throughput</h3>
     <pre><code>rate(firnflow_s3_requests_total{operation="upsert"}[5m])</code></pre>
+
+    <h3>Namespaces paying cold-open cost</h3>
+    <p>Active namespaces without a pooled connection handle. The first request to any of these will re-run the S3 credential resolution and manifest read:</p>
+    <pre><code>firnflow_active_namespaces - firnflow_cached_handles</code></pre>
 
     <h2>Alerting rules</h2>
     <p>Suggested Prometheus alerting rules for production deployments:</p>
@@ -250,6 +260,11 @@ groups:
           <td>Active namespaces</td>
           <td>Stat</td>
           <td><code>firnflow_active_namespaces</code></td>
+        </tr>
+        <tr>
+          <td>Pooled connection handles</td>
+          <td>Stat</td>
+          <td><code>firnflow_cached_handles</code></td>
         </tr>
         <tr>
           <td>Write latency (p50, p99)</td>

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -135,8 +135,10 @@ curl -X POST http://localhost:3000/ns/articles/fts-index</code></pre>
     <p>Key lines to look for:</p>
     <pre><code>firnflow_cache_hits_total{namespace="demo"} 1
 firnflow_cache_misses_total{namespace="demo"} 1
-firnflow_s3_requests_total{namespace="demo",operation="query"} 1</code></pre>
-    <p>The cache miss count stays at 1 no matter how many times you repeat the same query. Every subsequent hit is free.</p>
+firnflow_s3_requests_total{namespace="demo",operation="query"} 1
+firnflow_active_namespaces 1
+firnflow_cached_handles 1</code></pre>
+    <p>The cache miss count stays at 1 no matter how many times you repeat the same query. Every subsequent hit is free. <code>firnflow_cached_handles</code> tracks namespaces with a warm LanceDB connection in the in-process pool &mdash; the first request to any namespace opens the connection, every later request reuses it.</p>
 
     <h2>Next steps</h2>
     <ul>


### PR DESCRIPTION
Add the new firnflow_cached_handles gauge to the monitoring metric reference and the dashboard suggestions table, plus a short PromQL snippet for 'active namespaces paying cold-open cost'.

Describe the per-namespace lancedb::Connection + Table pool in the architecture page (new 'Connection pool' section, with the same eviction triggers the implementation uses) and extend the query-path bullet to mention the pool explicitly.

Include the gauge line in the quickstart's sample /metrics output so operators see the same shape in the docs and at runtime.