### PR TITLE
Post-0.2.0 cleanup: bench, clippy lint, doc license

### DIFF
--- a/crates/firnflow-api/tests/api_compact.rs
+++ b/crates/firnflow-api/tests/api_compact.rs
@@ -170,9 +170,11 @@ async fn compact_reduces_fragments_after_many_upserts() {
         assert_eq!(status, StatusCode::OK, "upsert batch {batch} failed");
     }
 
-    // 2. Verify all rows are queryable pre-compaction.
+    // 2. Verify all rows are queryable pre-compaction. Query vector
+    //    matches the id=0 row from the upsert loop above (id * 7919
+    //    drops out when id is 0).
     let query_vec: Vec<f32> = (0..dim)
-        .map(|j| (((0 * 7919 + j * 31) as f32) * 0.001).sin())
+        .map(|j| (((j * 31) as f32) * 0.001).sin())
         .collect();
     let (status, body) = post_json(
         app.clone(),
@@ -220,9 +222,10 @@ async fn compact_reduces_fragments_after_many_upserts() {
 
     // 6. Verify data integrity: query still returns results after
     //    compaction. The cache was invalidated by the service, so
-    //    this goes through the compacted data files.
+    //    this goes through the compacted data files. Same id=0
+    //    query vector as step 2.
     let query_vec: Vec<f32> = (0..dim)
-        .map(|j| (((0 * 7919 + j * 31) as f32) * 0.001).sin())
+        .map(|j| (((j * 31) as f32) * 0.001).sin())
         .collect();
     let (status, body) = post_json(
         app,

--- a/crates/firnflow-core/benches/serialisation.rs
+++ b/crates/firnflow-core/benches/serialisation.rs
@@ -41,6 +41,7 @@ fn make_result_set(n: usize) -> QueryResultSet {
             vector: (0..VECTOR_DIM)
                 .map(|j| ((i * 7 + j * 13) as f32) * 0.0001)
                 .collect(),
+            text: None,
         })
         .collect();
     QueryResultSet {

--- a/docs/api.html
+++ b/docs/api.html
@@ -381,7 +381,7 @@
 </div>
 
 <footer class="site-footer">
-  Firn is open source under the MIT License.
+  Firn is open source under the Apache 2.0 License.
   <a href="https://github.com/gordonmurray/firnflow">GitHub</a>
 </footer>
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -200,7 +200,7 @@
 </div>
 
 <footer class="site-footer">
-  Firn is open source under the MIT License.
+  Firn is open source under the Apache 2.0 License.
   <a href="https://github.com/gordonmurray/firnflow">GitHub</a>
 </footer>
 

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -190,7 +190,7 @@ RUST_LOG=info</code></pre>
 </div>
 
 <footer class="site-footer">
-  Firn is open source under the MIT License.
+  Firn is open source under the Apache 2.0 License.
   <a href="https://github.com/gordonmurray/firnflow">GitHub</a>
 </footer>
 

--- a/docs/deployment.html
+++ b/docs/deployment.html
@@ -217,7 +217,7 @@ readinessProbe:
 </div>
 
 <footer class="site-footer">
-  Firn is open source under the MIT License.
+  Firn is open source under the Apache 2.0 License.
   <a href="https://github.com/gordonmurray/firnflow">GitHub</a>
 </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,7 +123,7 @@
 </div>
 
 <footer class="site-footer">
-  Firn is open source under the MIT License.
+  Firn is open source under the Apache 2.0 License.
   <a href="https://github.com/gordonmurray/firnflow">GitHub</a>
 </footer>
 

--- a/docs/monitoring.html
+++ b/docs/monitoring.html
@@ -300,7 +300,7 @@ groups:
 </div>
 
 <footer class="site-footer">
-  Firn is open source under the MIT License.
+  Firn is open source under the Apache 2.0 License.
   <a href="https://github.com/gordonmurray/firnflow">GitHub</a>
 </footer>
 

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -152,7 +152,7 @@ firnflow_cached_handles 1</code></pre>
 </div>
 
 <footer class="site-footer">
-  Firn is open source under the MIT License.
+  Firn is open source under the Apache 2.0 License.
   <a href="https://github.com/gordonmurray/firnflow">GitHub</a>
 </footer>
 


### PR DESCRIPTION
## Summary
Three small cleanups that surfaced while verifying #17 and shipping v0.2.0.

## What changed
- `fix: restore bench compile on cargo check --all-targets` — `QueryResult` gained a nullable `text` field in phase 7, but `benches/serialisation.rs` was never updated. Adds `text: None` to the generator so `cargo check --all-targets` passes.
- `test: drop dead 0 * 7919 term from compact query vectors` — two query-vector generators in `api_compact.rs` mirrored the upsert loop exactly, keeping a `0 * 7919` term that trips `clippy::erasing_op` / `clippy::identity_op` under `cargo clippy --tests -- -D warnings`. Term dropped, id=0 intent preserved in a comment.
- `docs: correct license footer to Apache-2.0` — every page on firnflow.io still said "MIT License" in the footer. The `LICENSE` file and `Cargo.toml` already switched to Apache-2.0 in v0.2.0; this brings the docs in line.

## Verification
- `./scripts/cargo check --all-targets` — clean
- `./scripts/cargo clippy --workspace --tests -- -D warnings` — clean
- `./scripts/cargo fmt --all -- --check` — clean
- `./scripts/cargo test --workspace --lib --bins` — 8 / 0