### PR TITLE
ci: gate PRs and main on workspace checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,120 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: short
+  # Tests fall back to these defaults when the env vars are not set,
+  # matching docker-compose.yml for local parity. Setting them
+  # explicitly in CI makes the wiring visible at a glance.
+  FIRNFLOW_S3_ENDPOINT: http://127.0.0.1:9000
+  FIRNFLOW_S3_ACCESS_KEY: minioadmin
+  FIRNFLOW_S3_SECRET_KEY: minioadmin
+  FIRNFLOW_S3_BUCKET: firnflow-test
+
+jobs:
+  test:
+    name: fmt / clippy / test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ubuntu-latest ships with ~14 GB free. Lance + DataFusion in
+      # debug profile fit, but the margin is thin once test binaries
+      # land. This action reclaims ~25 GB without touching anything
+      # the build needs.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - name: Install protobuf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            protobuf-compiler libprotobuf-dev
+
+      # Rust 1.94 matches Dockerfile.dev. rustfmt / clippy must be
+      # installed as components up front — CLAUDE.md calls out that
+      # rustup's proxy misreports them as missing otherwise.
+      - name: Install Rust 1.94
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Makes the cache key depend on Cargo.lock so a dependency
+          # change busts the cache cleanly. Default already does this;
+          # restated here for clarity.
+          shared-key: ci
+          cache-on-failure: true
+
+      # Pull the MinIO image once, start it in the background, then
+      # create the bucket the integration tests default to. Using a
+      # plain `docker run` (rather than GHA `services:`) keeps the
+      # CMD for `server /data` readable and lets us do bucket init
+      # inline in the same job.
+      - name: Start MinIO and create test bucket
+        run: |
+          docker run -d --name minio \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z \
+            server /data --console-address ":9001"
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:9000/minio/health/live; then
+              echo "minio is up"
+              break
+            fi
+            sleep 1
+          done
+          docker run --rm --network host minio/mc:latest \
+            /bin/sh -c "
+              mc alias set local http://127.0.0.1:9000 minioadmin minioadmin &&
+              mc mb --ignore-existing local/firnflow-test
+            "
+
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo test (unit + default)
+        run: cargo test --workspace --no-fail-fast
+
+      # MinIO-backed integration tests are all gated #[ignore] so the
+      # previous step skips them. This step opts them in, minus:
+      #   * `_aws` variants — need real AWS credentials, not in CI
+      #   * `_100_runs_*` — spike-2 stress suites, overkill per PR
+      - name: cargo test (integration, MinIO-backed)
+        run: |
+          cargo test --workspace --no-fail-fast -- \
+            --include-ignored \
+            --skip _aws \
+            --skip _100_runs_
+
+      - name: Dump MinIO logs on failure
+        if: failure()
+        run: docker logs minio --tail 200 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,11 @@ jobs:
             fi
             sleep 1
           done
-          docker run --rm --network host minio/mc:latest \
-            /bin/sh -c "
+          # The mc image's ENTRYPOINT is `mc`, so a literal `/bin/sh`
+          # gets passed as an mc subcommand and rejected. Override the
+          # entrypoint so we can chain `alias set` + `mb` in one run.
+          docker run --rm --network host --entrypoint /bin/sh \
+            minio/mc:latest -c "
               mc alias set local http://127.0.0.1:9000 minioadmin minioadmin &&
               mc mb --ignore-existing local/firnflow-test
             "


### PR DESCRIPTION
Closes no existing issue.

## Summary
Every check that ran on PR #18 happened locally. A bench compile error and a clippy-with-tests lint had been sitting on main for multiple releases because nothing automated was looking. This workflow gates every pull_request and every push to main on the commands that would have caught that class of bug, plus the full MinIO-backed integration suite.

## What changed
- Adds `.github/workflows/ci.yml`. Single job on `ubuntu-latest` with a 45-minute timeout.
- Runs, in order: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (the 8 default unit tests), `cargo test --workspace -- --include-ignored --skip _aws --skip _100_runs_` (all MinIO-backed integration tests).
- MinIO comes up as a plain backgrounded container on the runner (simpler than GHA `services:` for the `server /data` CMD), with the default `firnflow-test` bucket created inline via a one-shot `mc` run.
- Real-AWS variants skipped — CI has no credentials. The spike-2 100-run stress suites are also skipped; they validated the backend during phase 2 and don't need to re-run on every PR.
- `Swatinem/rust-cache@v2` carries the Lance/DataFusion build graph between runs. First run cold is ~8–12 min to compile; subsequent runs reuse artefacts and should land well under that.
- `jlumbroso/free-disk-space` up front gives the runner enough `target/` headroom. `tool-cache` deliberately left in place to avoid evicting the Rust install.
- `concurrency.cancel-in-progress: true` drops superseded runs on the same ref so force-pushes don't queue up stale jobs.

## Verification
YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(...))'`). The actual signal comes from this PR's own CI run — if the workflow is wrong the first run here is where we'll see it.

## Rollback
`git revert` this commit or delete the file. No runtime impact outside of CI.