### PR TITLE
docs: add storage backend compatibility matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Firn
 
-**Firn** is a high-performance, multi-tenant vector and full-text search engine backed by object storage (S3 / MinIO / R2 / GCS). It is designed as a credible open-source alternative to turbopuffer, proving that a professional-grade tiered storage architecture (**RAM → NVMe → S3**) is achievable entirely from open-source components.
+**Firn** is a high-performance, multi-tenant vector and full-text search engine backed by object storage (AWS S3, MinIO, Cloudflare R2). It is designed as a credible open-source alternative to turbopuffer, proving that a professional-grade tiered storage architecture (**RAM → NVMe → S3**) is achievable entirely from open-source components. See [Storage backends](#storage-backends) for the full compatibility matrix.
 
 The cost efficiency of S3 with the speed of local RAM. A multi-tenant vector and full-text search engine backed by S3. Built with LanceDB and Foyer for microsecond-scale search latency on top of object storage.
 
@@ -34,6 +34,21 @@ Cold query, warm query, full-text search, and cache proof — all in 60 seconds.
 *   **LanceDB:** Vector and BM25 search engine that runs natively on object storage.
 *   **foyer:** Advanced hybrid cache (RAM + NVMe) with LFU/LRU eviction.
 *   **Prometheus:** Full operational visibility into cache hits, misses, and S3 request savings.
+
+## Storage backends
+
+Firn's correctness depends on S3's `If-None-Match: *` precondition behaving as a strictly linearisable compare-and-swap across concurrent writers. LanceDB's commit protocol uses it to serialise manifest updates, so a backend that ignores or incorrectly handles this header will silently lose writes. Every provider below has been tested with the same two checks: a sequential conditional-PUT pre-flight, and an 8-writer x 100-row concurrent stress (the passing backends additionally survive 100 consecutive runs). The test harness is in `crates/firnflow-core/tests/`.
+
+| Provider | Supported | Reason |
+| --- | :---: | --- |
+| **AWS S3** (`eu-west-1` validated) | ✅ | Strict CAS, clean pass on 100-run stress. |
+| **MinIO** (self-hosted / local) | ✅ | Reference implementation for the S3 protocol; clean pass on 100-run stress. |
+| **Cloudflare R2** | ✅ | `If-None-Match: *` honoured correctly; 100-run stress clean. Per-iteration latency is roughly 7x AWS due to R2's multi-region commit path, but correctness is what the gate checks. Zero egress makes this the most interesting non-AWS target. Use path-style addressing. |
+| **Backblaze B2** (S3 compat layer) | ❌ | Returns `HTTP 501 NotImplemented` on the first PutObject with `If-None-Match: *`. B2's native API supports conditional writes via `X-Bz-*` headers, but the S3-compat gateway does not translate them. Loud failure: easy to detect, not usable for Firn. |
+| **Tigris** (dual-region + single-region) | ❌ | Passes the sequential pre-flight but loses whole writer batches under concurrent stress. Dual-region: 0/6 runs clean. Single-region: 3/10 runs clean, 7/10 lost 1 to 3 writers. CAS primitive is not strictly linearisable even within a single region. |
+| **Google Cloud Storage** (via S3 interop) | ❌ | Silently ignores `If-None-Match: *`: the second conditional PUT returns `200 OK` instead of `412`. Concurrent stress loses 6/8 writers every run, deterministically. GCS's native `x-goog-if-generation-match: 0` works correctly; only the S3-interop translation is broken. A future release could support GCS via LanceDB's native GCS backend rather than the S3 layer. |
+
+The two dedicated tests live at `crates/firnflow-core/tests/s3_conditional_writes.rs` and `crates/firnflow-core/tests/lance_concurrent_writes.rs`. Both are `#[ignore]`'d and require credentials to run. If you want to evaluate a backend not in the table, copy a block from either file and point it at your own bucket.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Every cache hit results in **zero** S3 requests, directly reducing your cloud bi
 
 ### Demo
 
-Cold query, warm query, full-text search, and cache proof — all in 60 seconds. This demo runs against local MinIO; on real AWS S3 the cold query takes 25 seconds instead of 109ms, making the cache speedup even more dramatic.
+Cold query, warm query, full-text search, and cache proof, all in 60 seconds. This demo runs against local MinIO; on real AWS S3 the cold query takes 25 seconds instead of 109ms, making the cache speedup even more dramatic.
 
 ![Firn demo](bench/demo.gif)
 
@@ -25,9 +25,9 @@ Cold query, warm query, full-text search, and cache proof — all in 60 seconds.
 
 **Firn** is built on a "Tiered Storage" philosophy:
 
-1.  **L1: RAM Cache** (via foyer) — Sub-microsecond access for the most frequent queries.
-2.  **L2: NVMe Cache** (via foyer) — Fast, durable cache for high-volume search results.
-3.  **L3: Object Storage** (via LanceDB + S3/MinIO) — The "Source of Truth" where every namespace is isolated under its own S3 prefix.
+1.  **L1: RAM Cache** (via foyer): Sub-microsecond access for the most frequent queries.
+2.  **L2: NVMe Cache** (via foyer): Fast, durable cache for high-volume search results.
+3.  **L3: Object Storage** (via LanceDB + S3/MinIO): The "Source of Truth" where every namespace is isolated under its own S3 prefix.
 
 ### Key Technologies
 *   **axum:** High-performance async REST API.


### PR DESCRIPTION
Part of #7.

## Summary
Add a Storage backends section to the README documenting which object storage providers have been tested against Firn's CAS requirement, and why the failing ones fail.