### PR TITLE
Add GET /ns/{namespace}/list endpoint for recent-content flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `GET /ns/{namespace}/list` — a narrow, cursor-paginated endpoint for "recent content" flows. Ordered by a new reserved system column `_ingested_at` (microsecond timestamp, populated at first write, never mutated). Supports `order_by=_ingested_at` only in v1, `order=asc|desc`, `limit` (default 50, capped at 500), and an opaque hex cursor. Bypasses the foyer cache so pagination tails do not pollute hot query entries (issue #22).
+- `NamespaceManager::list` + `encode_list_cursor` / `decode_list_cursor` helpers. Cursor format is a 32-char hex encoding of `(timestamp_micros, id)` for stable continuation under concurrent writes.
+- `FirnflowError::Unsupported` variant mapped to HTTP 501 for namespaces whose tables pre-date the `_ingested_at` column.
+
+### Changed
+- `NamespaceManager` now caches `(dim, has_ingested_at)` per namespace (`schema_info` replaces the old `dims` DashMap). Existing namespaces without `_ingested_at` continue to accept upserts against their original schema; only the `/list` endpoint rejects them with 501.
+
 ## [0.2.0] - 2026-04-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +77,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arc-swap"
@@ -1034,6 +1054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1203,16 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1319,7 +1367,7 @@ dependencies = [
  "crc",
  "digest",
  "rustversion",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2135,6 +2183,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,15 +2275,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools 0.11.0",
+ "num-traits",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
+ "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -2241,12 +2310,12 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
- "der",
+ "der 0.6.1",
  "digest",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2387,6 +2456,7 @@ dependencies = [
  "dashmap",
  "foyer",
  "futures",
+ "lance",
  "lancedb",
  "object_store",
  "prometheus",
@@ -2423,6 +2493,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fnv"
@@ -2730,6 +2806,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+ "spade",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+dependencies = [
+ "geo-types",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rayon",
+ "rstar",
+ "serde",
+]
+
+[[package]]
+name = "geoarrow-array"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "geo-traits",
+ "geoarrow-schema",
+ "num-traits",
+ "wkb",
+ "wkt",
+]
+
+[[package]]
+name = "geoarrow-expr-geo"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa84300361ce57fb875bcaa6e32b95b0aff5c6b1af692b936bdd58ff343f4394"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "geo",
+ "geo-traits",
+ "geoarrow-array",
+ "geoarrow-schema",
+]
+
+[[package]]
+name = "geoarrow-schema"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
+dependencies = [
+ "arrow-schema",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "geodatafusion"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb8faa9b3bf4ae9f49b1f023b82d20626826f6448a7055498376146c10c4ead"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-schema",
+ "datafusion",
+ "geo",
+ "geo-traits",
+ "geoarrow-array",
+ "geoarrow-expr-geo",
+ "geoarrow-schema",
+ "geohash",
+ "thiserror 1.0.69",
+ "wkt",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "geohash"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb94b1a65401d6cbf22958a9040aa364812c26674f841bee538b12c135db1e6"
+dependencies = [
+ "geo-types",
+ "libm",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +3047,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +3094,16 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -3114,6 +3331,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "i_float"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+
+[[package]]
+name = "i_overlay"
+version = "4.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,6 +3536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3300,6 +3570,15 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -3410,6 +3689,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lance"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3743,7 @@ dependencies = [
  "lance-datafusion",
  "lance-encoding",
  "lance-file",
+ "lance-geo",
  "lance-index",
  "lance-io",
  "lance-linalg",
@@ -3571,6 +3866,7 @@ dependencies = [
  "lance-arrow",
  "lance-core",
  "lance-datagen",
+ "lance-geo",
  "log",
  "pin-project",
  "prost",
@@ -3674,6 +3970,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-geo"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8467185e6379cc0a0982caa88b000ac24b1f1fb4353dc65b81d00ba15e2eb8"
+dependencies = [
+ "datafusion",
+ "geo-traits",
+ "geo-types",
+ "geoarrow-array",
+ "geoarrow-schema",
+ "geodatafusion",
+ "lance-core",
+ "serde",
+]
+
+[[package]]
 name = "lance-index"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +4014,9 @@ dependencies = [
  "dirs",
  "fst",
  "futures",
+ "geo-types",
+ "geoarrow-array",
+ "geoarrow-schema",
  "half",
  "itertools 0.13.0",
  "jsonb",
@@ -3711,6 +4026,7 @@ dependencies = [
  "lance-datagen",
  "lance-encoding",
  "lance-file",
+ "lance-geo",
  "lance-io",
  "lance-linalg",
  "lance-table",
@@ -3975,6 +4291,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -4395,6 +4714,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4419,6 +4754,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,6 +4785,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "object_store"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,6 +4820,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
+ "httparse",
  "humantime",
  "hyper 1.9.0",
  "itertools 0.14.0",
@@ -4462,6 +4831,7 @@ dependencies = [
  "rand 0.9.3",
  "reqwest",
  "ring",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4526,6 +4896,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "url",
  "uuid",
@@ -4636,6 +5007,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,13 +5110,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der 0.7.10",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4772,6 +5210,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -5181,11 +5628,14 @@ dependencies = [
  "hmac",
  "home",
  "http 1.4.0",
+ "jsonwebtoken",
  "log",
+ "once_cell",
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.5",
  "reqwest",
+ "rsa",
  "rust-ini",
  "serde",
  "serde_json",
@@ -5273,6 +5723,44 @@ checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -5376,6 +5864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,6 +5915,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -5474,6 +5980,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5490,9 +6007,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -5698,6 +6215,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5708,6 +6235,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -5805,6 +6344,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5817,7 +6374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -6299,6 +6866,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -6973,6 +7570,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7058,6 +7664,31 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wkb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a120b336c7ad17749026d50427c23d838ecb50cd64aaea6254b5030152f890a9"
+dependencies = [
+ "byteorder",
+ "geo-traits",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wkt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ curl http://localhost:3000/metrics | grep s3_requests
 | `/ns/{ns}` | `DELETE` | Removes all data (S3 + Cache) for a namespace |
 | `/ns/{ns}/upsert` | `POST` | Insert/update vectors and data |
 | `/ns/{ns}/query` | `POST` | Vector, FTS, or hybrid search |
+| `/ns/{ns}/list` | `GET` | Cursor-paginated list ordered by `_ingested_at` |
 | `/ns/{ns}/warmup` | `POST` | Non-blocking cache pre-warm hint |
 | `/ns/{ns}/index` | `POST` | Build IVF_PQ vector index (async, returns 202) |
 | `/ns/{ns}/fts-index` | `POST` | Build BM25 full-text search index (async, returns 202) |

--- a/crates/firnflow-api/src/error.rs
+++ b/crates/firnflow-api/src/error.rs
@@ -32,6 +32,9 @@ impl IntoResponse for ApiError {
             FirnflowError::InvalidRequest(msg) => {
                 (StatusCode::BAD_REQUEST, format!("invalid request: {msg}"))
             }
+            FirnflowError::Unsupported(msg) => {
+                (StatusCode::NOT_IMPLEMENTED, format!("not supported: {msg}"))
+            }
             err @ (FirnflowError::Backend(_)
             | FirnflowError::Cache(_)
             | FirnflowError::Io(_)

--- a/crates/firnflow-api/src/handlers.rs
+++ b/crates/firnflow-api/src/handlers.rs
@@ -3,14 +3,17 @@
 //! * `GET    /health`
 //! * `POST   /ns/{namespace}/upsert`
 //! * `POST   /ns/{namespace}/query`
+//! * `GET    /ns/{namespace}/list`
 //! * `DELETE /ns/{namespace}`
 //! * `POST   /ns/{namespace}/warmup`
 //! * `POST   /ns/{namespace}/index`
+//! * `POST   /ns/{namespace}/fts-index`
+//! * `POST   /ns/{namespace}/compact`
 //! * `GET    /metrics`
 
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::header::CONTENT_TYPE;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -18,7 +21,8 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use firnflow_core::{
-    IndexRequest, NamespaceId, QueryRequest, QueryResultSet, UpsertRow as CoreUpsertRow,
+    decode_list_cursor, FirnflowError, IndexRequest, ListOrder, ListPage, NamespaceId,
+    QueryRequest, QueryResultSet, UpsertRow as CoreUpsertRow, LIST_MAX_LIMIT,
 };
 
 use crate::error::ApiError;
@@ -292,6 +296,79 @@ pub async fn compact(
             status: "compaction queued".into(),
         }),
     ))
+}
+
+const DEFAULT_LIST_LIMIT: usize = 50;
+const LIST_ORDER_BY: &str = "_ingested_at";
+
+/// Query parameters for `GET /ns/{namespace}/list`.
+///
+/// All fields are optional to keep simple "give me the latest"
+/// clients to a bare path. Defaults: `order_by=_ingested_at`,
+/// `order=desc`, `limit=50`, no cursor.
+#[derive(Debug, Deserialize)]
+pub struct ListParams {
+    #[serde(default)]
+    pub order_by: Option<String>,
+    #[serde(default)]
+    pub order: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub cursor: Option<String>,
+}
+
+/// List rows in a namespace ordered by `_ingested_at`.
+///
+/// Deliberately **does not** go through `NamespaceService`: pagination
+/// tails would pollute the foyer cache with cold one-shot entries. The
+/// handler calls `state.manager.list(...)` directly.
+pub async fn list(
+    State(state): State<AppState>,
+    Path(namespace): Path<String>,
+    Query(params): Query<ListParams>,
+) -> Result<Json<ListPage>, ApiError> {
+    let ns = NamespaceId::new(namespace)?;
+
+    // V1 only supports `_ingested_at`. User-column ordering is
+    // gated behind scalar-index support, which is a separate issue.
+    if let Some(col) = params.order_by.as_deref() {
+        if col != LIST_ORDER_BY {
+            return Err(ApiError(FirnflowError::InvalidRequest(format!(
+                "order_by must be {LIST_ORDER_BY:?} in v1, got {col:?}"
+            ))));
+        }
+    }
+
+    let order = match params.order.as_deref().unwrap_or("desc") {
+        "desc" => ListOrder::Desc,
+        "asc" => ListOrder::Asc,
+        other => {
+            return Err(ApiError(FirnflowError::InvalidRequest(format!(
+                "order must be \"asc\" or \"desc\", got {other:?}"
+            ))));
+        }
+    };
+
+    let limit = params.limit.unwrap_or(DEFAULT_LIST_LIMIT);
+    if limit == 0 {
+        return Err(ApiError(FirnflowError::InvalidRequest(
+            "limit must be >= 1".into(),
+        )));
+    }
+    if limit > LIST_MAX_LIMIT {
+        return Err(ApiError(FirnflowError::InvalidRequest(format!(
+            "limit {limit} exceeds maximum {LIST_MAX_LIMIT}"
+        ))));
+    }
+
+    let cursor = match params.cursor.as_deref() {
+        Some(raw) if !raw.is_empty() => Some(decode_list_cursor(raw)?),
+        _ => None,
+    };
+
+    let page = state.manager.list(&ns, limit, order, cursor).await?;
+    Ok(Json(page))
 }
 
 /// Prometheus scrape endpoint. Serialises the process-wide

--- a/crates/firnflow-api/src/lib.rs
+++ b/crates/firnflow-api/src/lib.rs
@@ -27,6 +27,7 @@ pub fn router(state: AppState) -> Router {
         .route("/ns/{namespace}", delete(handlers::delete))
         .route("/ns/{namespace}/upsert", post(handlers::upsert))
         .route("/ns/{namespace}/query", post(handlers::query))
+        .route("/ns/{namespace}/list", get(handlers::list))
         .route("/ns/{namespace}/warmup", post(handlers::warmup))
         .route("/ns/{namespace}/index", post(handlers::create_index))
         .route(

--- a/crates/firnflow-api/src/state.rs
+++ b/crates/firnflow-api/src/state.rs
@@ -16,7 +16,13 @@ use crate::config::AppConfig;
 #[derive(Clone)]
 pub struct AppState {
     /// Service facade combining the cache and the namespace manager.
+    /// Every cached read/write path goes through this.
     pub service: Arc<NamespaceService>,
+    /// Direct manager handle for the one endpoint that intentionally
+    /// bypasses the foyer cache (the `/list` path). Shares its
+    /// underlying `NamespaceManager` with `service`; holding a
+    /// separate `Arc` makes the architectural split explicit.
+    pub manager: Arc<NamespaceManager>,
     /// Shared metrics registry; the `/metrics` handler encodes
     /// this into the Prometheus text format.
     pub metrics: Arc<CoreMetrics>,
@@ -56,6 +62,14 @@ pub async fn build_state(cfg: &AppConfig) -> anyhow::Result<AppState> {
         .map_err(|e| anyhow::anyhow!("build namespace cache: {e}"))?,
     );
 
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
-    Ok(AppState { service, metrics })
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
+    Ok(AppState {
+        service,
+        manager,
+        metrics,
+    })
 }

--- a/crates/firnflow-api/tests/api_compact.rs
+++ b/crates/firnflow-api/tests/api_compact.rs
@@ -79,9 +79,14 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
     let app = router(AppState {
         service,
+        manager,
         metrics: Arc::clone(&metrics),
     });
     (app, tmp, metrics)

--- a/crates/firnflow-api/tests/api_delete.rs
+++ b/crates/firnflow-api/tests/api_delete.rs
@@ -73,8 +73,16 @@ async fn build_app() -> (axum::Router, tempfile::TempDir) {
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
-    let app = router(AppState { service, metrics });
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
+    let app = router(AppState {
+        service,
+        manager,
+        metrics,
+    });
     (app, tmp)
 }
 

--- a/crates/firnflow-api/tests/api_fts.rs
+++ b/crates/firnflow-api/tests/api_fts.rs
@@ -90,9 +90,14 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
     let app = router(AppState {
         service,
+        manager,
         metrics: Arc::clone(&metrics),
     });
     (app, tmp, metrics)

--- a/crates/firnflow-api/tests/api_index.rs
+++ b/crates/firnflow-api/tests/api_index.rs
@@ -81,9 +81,14 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
     let app = router(AppState {
         service,
+        manager,
         metrics: Arc::clone(&metrics),
     });
     (app, tmp, metrics)

--- a/crates/firnflow-api/tests/api_list.rs
+++ b/crates/firnflow-api/tests/api_list.rs
@@ -1,0 +1,300 @@
+//! Integration test for `GET /ns/{namespace}/list` (issue #22).
+//!
+//! Drives the axum router via `tower::ServiceExt::oneshot`, so no TCP
+//! listener is required. Covers:
+//!
+//! - happy path: upsert rows, list them back, assert order + shape,
+//! - pagination via `?limit` + `?cursor`,
+//! - 400 on bogus `order_by` / malformed cursor / over-limit,
+//! - cache bypass: hit + miss counters do not advance across list
+//!   calls (the foyer cache is owned by `NamespaceService`, and
+//!   `/list` goes through the manager directly).
+//!
+//! Gated `#[ignore]`: needs MinIO up.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use firnflow_api::{router, AppState};
+use firnflow_core::cache::NamespaceCache;
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{CoreMetrics, NamespaceManager, NamespaceService};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn unique_namespace(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "aws_access_key_id".into(),
+            env_or("FIRNFLOW_S3_ACCESS_KEY", "minioadmin"),
+        ),
+        (
+            "aws_secret_access_key".into(),
+            env_or("FIRNFLOW_S3_SECRET_KEY", "minioadmin"),
+        ),
+        (
+            "aws_endpoint".into(),
+            env_or("FIRNFLOW_S3_ENDPOINT", "http://127.0.0.1:9000"),
+        ),
+        ("aws_region".into(), "us-east-1".into()),
+        ("allow_http".into(), "true".into()),
+        ("aws_virtual_hosted_style_request".into(), "false".into()),
+    ])
+}
+
+async fn build_app() -> (axum::Router, Arc<CoreMetrics>, tempfile::TempDir) {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let tmp = tempfile::tempdir().unwrap();
+    let metrics = test_metrics();
+    let manager = Arc::new(NamespaceManager::new(
+        bucket,
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
+    let cache = Arc::new(
+        NamespaceCache::new(
+            16 * 1024 * 1024,
+            tmp.path(),
+            64 * 1024 * 1024,
+            Arc::clone(&metrics),
+        )
+        .await
+        .unwrap(),
+    );
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
+    let app = router(AppState {
+        service,
+        manager,
+        metrics: Arc::clone(&metrics),
+    });
+    (app, metrics, tmp)
+}
+
+async fn post_json(app: axum::Router, uri: String, body: Value) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, json)
+}
+
+async fn get(app: axum::Router, uri: String) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, json)
+}
+
+async fn get_metrics_text(app: axum::Router) -> String {
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+fn sum_counter(metrics_text: &str, metric: &str) -> u64 {
+    metrics_text
+        .lines()
+        .filter(|l| l.starts_with(metric) && !l.starts_with('#'))
+        .filter_map(|l| l.split_whitespace().last())
+        .filter_map(|v| v.parse::<f64>().ok())
+        .map(|v| v as u64)
+        .sum()
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_happy_path_desc_and_pagination() {
+    let (app, _metrics, _tmp) = build_app().await;
+    let ns = unique_namespace("issue22-api");
+
+    // Seed two batches with a sleep so their _ingested_at timestamps
+    // differ. Within a batch, order is decided by id.
+    for batch in 0..2 {
+        let base = batch * 4;
+        let body = json!({
+            "rows": [
+                {"id": base, "vector": [1.0, 0.0, 0.0, 0.0]},
+                {"id": base + 1, "vector": [0.0, 1.0, 0.0, 0.0]},
+                {"id": base + 2, "vector": [0.0, 0.0, 1.0, 0.0]},
+                {"id": base + 3, "vector": [0.0, 0.0, 0.0, 1.0]},
+            ]
+        });
+        let (status, _) = post_json(app.clone(), format!("/ns/{ns}/upsert"), body).await;
+        assert_eq!(status, StatusCode::OK);
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    // First page — limit=3 forces a cursor.
+    let (status, page1) = get(app.clone(), format!("/ns/{ns}/list?limit=3")).await;
+    assert_eq!(status, StatusCode::OK, "first page: {page1}");
+    let rows1 = page1["rows"].as_array().expect("rows array");
+    assert_eq!(rows1.len(), 3, "first page returns `limit` rows");
+    let cursor = page1["next_cursor"]
+        .as_str()
+        .expect("cursor present mid-stream")
+        .to_string();
+
+    // Ids on page 1 must be the three most-recent. Batch 2 (ids 4..7)
+    // shares a timestamp, so desc order within it is 7, 6, 5.
+    let page1_ids: Vec<u64> = rows1.iter().map(|r| r["id"].as_u64().unwrap()).collect();
+    assert_eq!(page1_ids, vec![7, 6, 5]);
+
+    // Second page — continue via cursor, pull the rest.
+    let (status, page2) = get(
+        app.clone(),
+        format!("/ns/{ns}/list?limit=10&cursor={cursor}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let rows2 = page2["rows"].as_array().unwrap();
+    let page2_ids: Vec<u64> = rows2.iter().map(|r| r["id"].as_u64().unwrap()).collect();
+    assert_eq!(
+        page2_ids,
+        vec![4, 3, 2, 1, 0],
+        "remaining rows in desc order"
+    );
+    assert!(
+        page2["next_cursor"].is_null(),
+        "final page must omit next_cursor"
+    );
+
+    // Shape spot-check on the first row: must carry ingested_at_micros.
+    let first = &rows1[0];
+    assert!(
+        first["ingested_at_micros"].as_i64().unwrap() > 0,
+        "ingested_at_micros must be populated"
+    );
+    assert_eq!(first["vector"].as_array().unwrap().len(), 4);
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_rejects_unsupported_order_by() {
+    let (app, _metrics, _tmp) = build_app().await;
+    let ns = unique_namespace("issue22-order-by");
+
+    let body = json!({
+        "rows": [{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]}]
+    });
+    let (status, _) = post_json(app.clone(), format!("/ns/{ns}/upsert"), body).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = get(app, format!("/ns/{ns}/list?order_by=created_at")).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("order_by"),
+        "expected order_by error, got {err}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_rejects_malformed_cursor() {
+    let (app, _metrics, _tmp) = build_app().await;
+    let ns = unique_namespace("issue22-cursor");
+
+    let body = json!({
+        "rows": [{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]}]
+    });
+    let (status, _) = post_json(app.clone(), format!("/ns/{ns}/upsert"), body).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _) = get(app, format!("/ns/{ns}/list?cursor=not-hex")).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_rejects_over_limit() {
+    let (app, _metrics, _tmp) = build_app().await;
+    // Namespace does not need to exist — limit validation runs first.
+    let (status, body) = get(app, "/ns/anything/list?limit=10000".to_string()).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(err.contains("limit"), "expected limit error, got {err}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_bypasses_foyer_cache() {
+    let (app, _metrics, _tmp) = build_app().await;
+    let ns = unique_namespace("issue22-cache");
+
+    // Seed a row.
+    let upsert_body = json!({
+        "rows": [{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]}]
+    });
+    let (status, _) = post_json(app.clone(), format!("/ns/{ns}/upsert"), upsert_body).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Baseline cache counters *before* any list call. Counters are
+    // captured after the upsert so any cache eviction from the write
+    // has already happened.
+    let text0 = get_metrics_text(app.clone()).await;
+    let hits0 = sum_counter(&text0, "firnflow_cache_hits_total");
+    let misses0 = sum_counter(&text0, "firnflow_cache_misses_total");
+
+    // Call list twice — both must skip the foyer cache.
+    for _ in 0..2 {
+        let (status, _) = get(app.clone(), format!("/ns/{ns}/list?limit=10")).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    let text1 = get_metrics_text(app).await;
+    let hits1 = sum_counter(&text1, "firnflow_cache_hits_total");
+    let misses1 = sum_counter(&text1, "firnflow_cache_misses_total");
+
+    assert_eq!(
+        hits1, hits0,
+        "cache hit counter advanced across list calls: {hits0} -> {hits1}"
+    );
+    assert_eq!(
+        misses1, misses0,
+        "cache miss counter advanced across list calls: {misses0} -> {misses1}"
+    );
+}

--- a/crates/firnflow-api/tests/api_metrics.rs
+++ b/crates/firnflow-api/tests/api_metrics.rs
@@ -83,8 +83,16 @@ async fn build_app() -> (axum::Router, tempfile::TempDir) {
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
-    let app = router(AppState { service, metrics });
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
+    let app = router(AppState {
+        service,
+        manager,
+        metrics,
+    });
     (app, tmp)
 }
 

--- a/crates/firnflow-api/tests/api_pool.rs
+++ b/crates/firnflow-api/tests/api_pool.rs
@@ -84,9 +84,14 @@ async fn build_app() -> (axum::Router, tempfile::TempDir, Arc<CoreMetrics>) {
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
     let app = router(AppState {
         service,
+        manager,
         metrics: Arc::clone(&metrics),
     });
     (app, tmp, metrics)

--- a/crates/firnflow-api/tests/api_smoke.rs
+++ b/crates/firnflow-api/tests/api_smoke.rs
@@ -82,8 +82,16 @@ async fn build_app() -> (axum::Router, tempfile::TempDir) {
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
-    let app = router(AppState { service, metrics });
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
+    let app = router(AppState {
+        service,
+        manager,
+        metrics,
+    });
     (app, tmp)
 }
 

--- a/crates/firnflow-api/tests/api_warmup.rs
+++ b/crates/firnflow-api/tests/api_warmup.rs
@@ -78,9 +78,14 @@ async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreM
         .await
         .unwrap(),
     );
-    let service = Arc::new(NamespaceService::new(manager, cache, Arc::clone(&metrics)));
+    let service = Arc::new(NamespaceService::new(
+        Arc::clone(&manager),
+        cache,
+        Arc::clone(&metrics),
+    ));
     let app = router(AppState {
         service,
+        manager,
         metrics: Arc::clone(&metrics),
     });
     (app, tmp, metrics)

--- a/crates/firnflow-core/Cargo.toml
+++ b/crates/firnflow-core/Cargo.toml
@@ -15,6 +15,7 @@ xxhash-rust.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 lancedb.workspace = true
+lance.workspace = true
 arrow-array.workspace = true
 arrow-schema.workspace = true
 futures.workspace = true

--- a/crates/firnflow-core/src/error.rs
+++ b/crates/firnflow-core/src/error.rs
@@ -26,6 +26,12 @@ pub enum FirnflowError {
     #[error("invalid request: {0}")]
     InvalidRequest(String),
 
+    /// The requested operation is not supported on this namespace,
+    /// typically because its schema pre-dates a feature. Maps to
+    /// HTTP 501 at the API layer.
+    #[error("operation not supported on this namespace: {0}")]
+    Unsupported(String),
+
     /// A metrics registry or encoding operation failed.
     #[error("metrics error: {0}")]
     Metrics(String),

--- a/crates/firnflow-core/src/lib.rs
+++ b/crates/firnflow-core/src/lib.rs
@@ -16,9 +16,12 @@ pub mod result;
 pub mod service;
 
 pub use error::FirnflowError;
-pub use manager::{CompactResult, NamespaceManager, UpsertRow};
+pub use manager::{
+    decode_list_cursor, encode_list_cursor, CompactResult, NamespaceManager, UpsertRow,
+    LIST_MAX_LIMIT,
+};
 pub use metrics::CoreMetrics;
 pub use namespace::NamespaceId;
 pub use query::{IndexRequest, QueryRequest};
-pub use result::{QueryResult, QueryResultSet};
+pub use result::{ListOrder, ListPage, ListRow, QueryResult, QueryResultSet};
 pub use service::NamespaceService;

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -11,11 +11,13 @@
 //! - **read from the Lance table schema** when re-opening an
 //!   existing namespace.
 //!
-//! Resolved dimensions are cached in a `DashMap<NamespaceId, usize>`
-//! so the schema-read / first-row-inference happens at most once per
-//! namespace per process lifetime. Entries stay until the process
-//! restarts or the namespace is deleted (in which case the stale
-//! entry is evicted lazily on next use).
+//! Resolved schema facts — the vector dimension and whether the
+//! table carries the `_ingested_at` system column — are cached in a
+//! `DashMap<NamespaceId, NamespaceSchemaInfo>` so the schema-read /
+//! first-row-inference happens at most once per namespace per process
+//! lifetime. Entries stay until the process restarts or the namespace
+//! is deleted (in which case the stale entry is evicted lazily on
+//! next use).
 //!
 //! **Connection pooling (issue #1):** each namespace's
 //! `lancedb::Connection` + `lancedb::Table` are cached in a
@@ -423,10 +425,10 @@ impl NamespaceManager {
     /// Remove every object under a namespace prefix from the
     /// underlying object store.
     ///
-    /// Also evicts the cached dimension **and** the pooled
-    /// connection/table handle for this namespace so that a
-    /// subsequent upsert can establish a new dimension against a
-    /// fresh Lance table.
+    /// Also evicts the cached schema info (dimension +
+    /// `_ingested_at` flag) **and** the pooled connection/table
+    /// handle for this namespace so that a subsequent upsert can
+    /// establish a new dimension against a fresh Lance table.
     ///
     /// Returns the number of objects deleted. The caller
     /// (`NamespaceService::delete`) is responsible for invalidating
@@ -713,6 +715,14 @@ impl NamespaceManager {
     ) -> Result<ListPage, FirnflowError> {
         let limit = limit.clamp(1, LIST_MAX_LIMIT);
 
+        // Every successful list call makes S3 requests (manifest +
+        // data reads via lance). Record one tick so the
+        // `firnflow_s3_requests_total{operation="list"}` counter
+        // preserves the cost-visibility story even though this path
+        // bypasses `NamespaceService`, where the other operations
+        // record theirs.
+        self.metrics.record_s3_request(ns, "list");
+
         let info = match self.resolve_schema_info(ns).await? {
             Some(i) => i,
             None => {
@@ -797,8 +807,10 @@ impl NamespaceManager {
 }
 
 /// Encode a `(timestamp_micros, id)` pair as a 32-character hex
-/// cursor. Opaque on the wire; the handler round-trips it via
-/// [`decode_list_cursor`].
+/// cursor. The encoding is implementation-defined and may change —
+/// clients must treat the returned string as an opaque token and
+/// round-trip it verbatim via [`decode_list_cursor`]. Parsing the
+/// bytes or constructing cursors by hand is not supported.
 pub fn encode_list_cursor(ts_micros: i64, id: u64) -> String {
     format!("{:016x}{:016x}", ts_micros as u64, id)
 }

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -32,15 +32,17 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use arrow_array::builder::{FixedSizeListBuilder, Float32Builder, StringBuilder};
 use arrow_array::{
     Array, ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator,
-    RecordBatchReader, StringArray, UInt64Array,
+    RecordBatchReader, StringArray, TimestampMicrosecondArray, UInt64Array,
 };
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use dashmap::DashMap;
 use futures::{StreamExt, TryStreamExt};
+use lance::dataset::scanner::ColumnOrdering;
 use lancedb::index::scalar::{FtsIndexBuilder, FullTextSearchQuery};
 use lancedb::index::vector::IvfPqIndexBuilder;
 use lancedb::index::Index;
@@ -53,12 +55,29 @@ use object_store::ObjectStore;
 
 use crate::metrics::CoreMetrics;
 use crate::query::DEFAULT_NPROBES;
+use crate::result::{ListOrder, ListPage, ListRow};
 use crate::{FirnflowError, NamespaceId, QueryResult, QueryResultSet};
 
 const TABLE_NAME: &str = "data";
 const DISTANCE_COLUMN: &str = "_distance";
 const SCORE_COLUMN: &str = "_score";
 const RELEVANCE_COLUMN: &str = "_relevance_score";
+const INGESTED_AT_COLUMN: &str = "_ingested_at";
+
+/// Maximum `limit` the `list` endpoint will honour per request.
+/// Hard-capped to bound in-memory sort cost while the v1 endpoint
+/// lacks scalar-index pushdown.
+pub const LIST_MAX_LIMIT: usize = 500;
+
+/// Per-namespace schema facts cached after the first table open.
+/// Both the resolved vector dimension and whether the table
+/// carries the `_ingested_at` system column come from the same
+/// schema read and are stored together.
+#[derive(Debug, Clone, Copy)]
+struct NamespaceSchemaInfo {
+    dim: usize,
+    has_ingested_at: bool,
+}
 
 /// A single row for upsert into a namespace.
 #[derive(Debug, Clone)]
@@ -108,9 +127,11 @@ struct NamespaceHandle {
 pub struct NamespaceManager {
     bucket: String,
     storage_options: HashMap<String, String>,
-    /// Per-namespace resolved dimensions. Populated on first
-    /// interaction with each namespace (upsert or query).
-    dims: DashMap<NamespaceId, usize>,
+    /// Per-namespace schema facts. Populated on first interaction
+    /// (upsert or query). Carries the resolved vector dimension and
+    /// a flag for whether the underlying Lance table has the
+    /// `_ingested_at` column that the `list` endpoint relies on.
+    schema_info: DashMap<NamespaceId, NamespaceSchemaInfo>,
     /// Per-namespace connection + table handles. Populated lazily
     /// by [`NamespaceManager::get_or_open_table`] and evicted on
     /// namespace delete / index build / compaction.
@@ -145,7 +166,7 @@ impl NamespaceManager {
         Self {
             bucket: bucket.into(),
             storage_options,
-            dims: DashMap::new(),
+            schema_info: DashMap::new(),
             handles: DashMap::new(),
             metrics,
         }
@@ -155,7 +176,17 @@ impl NamespaceManager {
     /// `None` for namespaces the manager has not yet interacted
     /// with.
     pub fn dim_for(&self, ns: &NamespaceId) -> Option<usize> {
-        self.dims.get(ns).map(|r| *r)
+        self.schema_info.get(ns).map(|r| r.dim)
+    }
+
+    /// Whether the namespace's Lance table carries the
+    /// `_ingested_at` system column required by the `list` endpoint.
+    /// Returns `None` for namespaces the manager has not yet
+    /// interacted with. `Some(false)` is returned for namespaces
+    /// whose tables were created before `_ingested_at` existed; the
+    /// list endpoint surfaces this as HTTP 501.
+    pub fn supports_list(&self, ns: &NamespaceId) -> Option<bool> {
+        self.schema_info.get(ns).map(|r| r.has_ingested_at)
     }
 
     /// Number of namespaces currently holding a pooled
@@ -177,8 +208,14 @@ impl NamespaceManager {
         format!("s3://{}/{}", self.bucket, ns.as_str())
     }
 
-    fn schema_for_dim(dim: usize) -> Arc<Schema> {
-        Arc::new(Schema::new(vec![
+    /// Build the Arrow schema for a namespace's Lance table.
+    ///
+    /// `with_ingested_at` controls whether the trailing
+    /// `_ingested_at` system column is included. Fresh namespaces
+    /// always use `true`; appends into pre-existing tables pass
+    /// whatever the live table schema reports so the batch matches.
+    fn schema_for_dim(dim: usize, with_ingested_at: bool) -> Arc<Schema> {
+        let mut fields = vec![
             Field::new("id", DataType::UInt64, false),
             Field::new(
                 "vector",
@@ -189,7 +226,15 @@ impl NamespaceManager {
                 false,
             ),
             Field::new("text", DataType::Utf8, true),
-        ]))
+        ];
+        if with_ingested_at {
+            fields.push(Field::new(
+                INGESTED_AT_COLUMN,
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                false,
+            ));
+        }
+        Arc::new(Schema::new(fields))
     }
 
     async fn connect(&self, ns: &NamespaceId) -> Result<lancedb::Connection, FirnflowError> {
@@ -232,6 +277,12 @@ impl NamespaceManager {
     /// fresh one is created with the `dim`-shaped schema. The
     /// resulting handle is cached in `self.handles` so the next
     /// caller hits the fast path.
+    /// Return a cached `lancedb::Table` for `ns`, opening (and if
+    /// necessary, creating) one on a cache miss.
+    ///
+    /// When the table must be created, it is built with the current
+    /// schema (including `_ingested_at`). If the table already
+    /// exists it is opened as-is — no schema migration is attempted.
     async fn get_or_open_table(
         &self,
         ns: &NamespaceId,
@@ -245,8 +296,10 @@ impl NamespaceManager {
         let table = match conn.open_table(TABLE_NAME).execute().await {
             Ok(tbl) => tbl,
             Err(_) => {
-                let schema = Self::schema_for_dim(dim);
-                let empty = rows_to_batch(&schema, dim, Vec::new())?;
+                // Fresh namespace: always create with the current
+                // schema, which includes `_ingested_at`.
+                let schema = Self::schema_for_dim(dim, true);
+                let empty = rows_to_batch(&schema, dim, Vec::new(), true)?;
                 let reader: Box<dyn RecordBatchReader + Send> =
                     Box::new(RecordBatchIterator::new(vec![Ok(empty)], schema));
                 conn.create_table(TABLE_NAME, reader)
@@ -262,43 +315,46 @@ impl NamespaceManager {
     }
 
     /// Try to open an existing table for `ns` without creating one.
-    /// Used by [`resolve_dim`] to discover a namespace's dimension
-    /// from its persisted schema. On success the handle is cached
-    /// so the subsequent operation avoids a second `open_table`.
+    /// Used by [`resolve_schema_info`] to discover a namespace's
+    /// dimension and ingested-at support from its persisted schema.
+    /// On success the handle is cached so the subsequent operation
+    /// avoids a second `open_table`.
     async fn open_existing(
         &self,
         ns: &NamespaceId,
-    ) -> Result<Option<(lancedb::Table, usize)>, FirnflowError> {
+    ) -> Result<Option<(lancedb::Table, NamespaceSchemaInfo)>, FirnflowError> {
         if let Some(entry) = self.handles.get(ns) {
             let tbl = entry.table.clone();
             drop(entry);
-            let dim = read_dim_from_table(&tbl).await?;
-            return Ok(Some((tbl, dim)));
+            let info = read_schema_info_from_table(&tbl).await?;
+            return Ok(Some((tbl, info)));
         }
 
         let conn = self.connect(ns).await?;
         match conn.open_table(TABLE_NAME).execute().await {
             Ok(tbl) => {
-                let dim = read_dim_from_table(&tbl).await?;
+                let info = read_schema_info_from_table(&tbl).await?;
                 self.cache_handle(ns, conn, tbl.clone());
-                Ok(Some((tbl, dim)))
+                Ok(Some((tbl, info)))
             }
             Err(_) => Ok(None),
         }
     }
 
-    /// Resolve the dimension for a namespace:
+    /// Resolve the schema facts for a namespace:
     /// 1. Check the in-memory cache.
     /// 2. Try reading from the existing Lance table schema.
     /// 3. Return `None` if the namespace doesn't exist yet.
-    async fn resolve_dim(&self, ns: &NamespaceId) -> Result<Option<usize>, FirnflowError> {
-        if let Some(dim) = self.dims.get(ns) {
-            return Ok(Some(*dim));
+    async fn resolve_schema_info(
+        &self,
+        ns: &NamespaceId,
+    ) -> Result<Option<NamespaceSchemaInfo>, FirnflowError> {
+        if let Some(info) = self.schema_info.get(ns) {
+            return Ok(Some(*info));
         }
-        // Not cached — try opening the table.
-        if let Some((_tbl, dim)) = self.open_existing(ns).await? {
-            self.dims.insert(ns.clone(), dim);
-            return Ok(Some(dim));
+        if let Some((_tbl, info)) = self.open_existing(ns).await? {
+            self.schema_info.insert(ns.clone(), info);
+            return Ok(Some(info));
         }
         Ok(None)
     }
@@ -319,34 +375,40 @@ impl NamespaceManager {
             return Ok(());
         }
 
-        // Determine the dimension: cached → schema-read → infer from row[0].
-        let dim = match self.resolve_dim(ns).await? {
-            Some(d) => d,
+        // Determine schema facts: cached → live schema → infer for
+        // a fresh namespace. Fresh namespaces always get the current
+        // schema (with `_ingested_at`); pre-upgrade tables keep their
+        // legacy shape so appends continue to work.
+        let info = match self.resolve_schema_info(ns).await? {
+            Some(info) => info,
             None => {
-                let d = rows[0].vector.len();
-                if d == 0 {
+                let dim = rows[0].vector.len();
+                if dim == 0 {
                     return Err(FirnflowError::InvalidRequest(
                         "row id 0: vector is empty".into(),
                     ));
                 }
-                d
+                NamespaceSchemaInfo {
+                    dim,
+                    has_ingested_at: true,
+                }
             }
         };
 
-        // Validate every row.
         for row in &rows {
-            if row.vector.len() != dim {
+            if row.vector.len() != info.dim {
                 return Err(FirnflowError::InvalidRequest(format!(
-                    "row id {}: vector length {}, expected {dim}",
+                    "row id {}: vector length {}, expected {}",
                     row.id,
                     row.vector.len(),
+                    info.dim,
                 )));
             }
         }
 
-        let tbl = self.get_or_open_table(ns, dim).await?;
-        let schema = Self::schema_for_dim(dim);
-        let batch = rows_to_batch(&schema, dim, rows)?;
+        let tbl = self.get_or_open_table(ns, info.dim).await?;
+        let schema = Self::schema_for_dim(info.dim, info.has_ingested_at);
+        let batch = rows_to_batch(&schema, info.dim, rows, info.has_ingested_at)?;
         let reader: Box<dyn RecordBatchReader + Send> =
             Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema));
         tbl.add(reader)
@@ -354,8 +416,7 @@ impl NamespaceManager {
             .await
             .map_err(|e| FirnflowError::Backend(format!("table.add: {e}")))?;
 
-        // Cache the dimension now that the write succeeded.
-        self.dims.insert(ns.clone(), dim);
+        self.schema_info.insert(ns.clone(), info);
         Ok(())
     }
 
@@ -386,8 +447,9 @@ impl NamespaceManager {
             count += 1;
         }
 
-        // Evict dim + pooled handle so a fresh upsert can pick a new dim.
-        self.dims.remove(ns);
+        // Evict cached schema info + pooled handle so a fresh
+        // upsert can pick a new dim.
+        self.schema_info.remove(ns);
         self.evict_handle(ns);
 
         Ok(count)
@@ -436,8 +498,8 @@ impl NamespaceManager {
         nprobes: Option<usize>,
         text: Option<String>,
     ) -> Result<QueryResultSet, FirnflowError> {
-        let dim = match self.resolve_dim(ns).await? {
-            Some(d) => d,
+        let dim = match self.resolve_schema_info(ns).await? {
+            Some(info) => info.dim,
             None => {
                 return Ok(QueryResultSet {
                     query_id: String::new(),
@@ -519,11 +581,15 @@ impl NamespaceManager {
         num_partitions: Option<u32>,
         num_sub_vectors: Option<u32>,
     ) -> Result<(), FirnflowError> {
-        let dim = self.resolve_dim(ns).await?.ok_or_else(|| {
-            FirnflowError::InvalidRequest(format!(
-                "cannot index namespace {ns}: no data has been upserted yet"
-            ))
-        })?;
+        let dim = self
+            .resolve_schema_info(ns)
+            .await?
+            .ok_or_else(|| {
+                FirnflowError::InvalidRequest(format!(
+                    "cannot index namespace {ns}: no data has been upserted yet"
+                ))
+            })?
+            .dim;
 
         let tbl = self.get_or_open_table(ns, dim).await?;
 
@@ -552,11 +618,15 @@ impl NamespaceManager {
     /// column. Requires that at least some rows have been upserted
     /// with non-null `text` values.
     pub async fn create_fts_index(&self, ns: &NamespaceId) -> Result<(), FirnflowError> {
-        let dim = self.resolve_dim(ns).await?.ok_or_else(|| {
-            FirnflowError::InvalidRequest(format!(
-                "cannot create FTS index on namespace {ns}: no data has been upserted yet"
-            ))
-        })?;
+        let dim = self
+            .resolve_schema_info(ns)
+            .await?
+            .ok_or_else(|| {
+                FirnflowError::InvalidRequest(format!(
+                    "cannot create FTS index on namespace {ns}: no data has been upserted yet"
+                ))
+            })?
+            .dim;
 
         let tbl = self.get_or_open_table(ns, dim).await?;
         tbl.create_index(&["text"], Index::FTS(FtsIndexBuilder::default()))
@@ -580,11 +650,15 @@ impl NamespaceManager {
     /// Like `create_index`, this is a potentially expensive
     /// operation and the caller should run it in a background task.
     pub async fn compact(&self, ns: &NamespaceId) -> Result<CompactResult, FirnflowError> {
-        let dim = self.resolve_dim(ns).await?.ok_or_else(|| {
-            FirnflowError::InvalidRequest(format!(
-                "cannot compact namespace {ns}: no data has been upserted yet"
-            ))
-        })?;
+        let dim = self
+            .resolve_schema_info(ns)
+            .await?
+            .ok_or_else(|| {
+                FirnflowError::InvalidRequest(format!(
+                    "cannot compact namespace {ns}: no data has been upserted yet"
+                ))
+            })?
+            .dim;
 
         let tbl = self.get_or_open_table(ns, dim).await?;
         let stats = tbl
@@ -606,6 +680,143 @@ impl NamespaceManager {
             fragments_added: added,
         })
     }
+
+    /// List rows from a namespace in `_ingested_at` order.
+    ///
+    /// This path deliberately does **not** participate in the foyer
+    /// cache — paginated scans would push hot query results out
+    /// with cold, one-shot list entries. Callers are expected to
+    /// invoke the manager directly.
+    ///
+    /// `limit` is clamped to [`LIST_MAX_LIMIT`]; `cursor` is the
+    /// `(timestamp_micros, id)` pair taken from the last row of the
+    /// previous page and filters out rows that appeared earlier in
+    /// the chosen order.
+    ///
+    /// Returns [`FirnflowError::Unsupported`] on namespaces whose
+    /// tables pre-date the `_ingested_at` column (HTTP 501 at the
+    /// API layer).
+    ///
+    /// **V1 performance note:** LanceDB 0.27's high-level query
+    /// API does not expose scalar-index ordering. The implementation
+    /// drops through to `lance::Dataset::scan()` with
+    /// `order_by`, which triggers a full scan of the fragments
+    /// matching the cursor filter before returning the first batch.
+    /// Acceptable for small-to-medium namespaces; a scalar index on
+    /// `_ingested_at` is the follow-up for scale.
+    pub async fn list(
+        &self,
+        ns: &NamespaceId,
+        limit: usize,
+        order: ListOrder,
+        cursor: Option<(i64, u64)>,
+    ) -> Result<ListPage, FirnflowError> {
+        let limit = limit.clamp(1, LIST_MAX_LIMIT);
+
+        let info = match self.resolve_schema_info(ns).await? {
+            Some(i) => i,
+            None => {
+                return Ok(ListPage {
+                    rows: Vec::new(),
+                    next_cursor: None,
+                });
+            }
+        };
+        if !info.has_ingested_at {
+            return Err(FirnflowError::Unsupported(format!(
+                "namespace {ns} pre-dates the _ingested_at column; \
+                 recreate the namespace or wait for the migration follow-up"
+            )));
+        }
+
+        let tbl = self.get_or_open_table(ns, info.dim).await?;
+        let dataset_wrapper = tbl
+            .dataset()
+            .ok_or_else(|| FirnflowError::Backend("list requires a native lance table".into()))?;
+        let dataset = dataset_wrapper
+            .get()
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("resolve dataset: {e}")))?;
+
+        let mut scan = dataset.scan();
+
+        if let Some((ts, id)) = cursor {
+            let filter = match order {
+                ListOrder::Desc => format!(
+                    "({INGESTED_AT_COLUMN} < to_timestamp_micros({ts})) \
+                     OR ({INGESTED_AT_COLUMN} = to_timestamp_micros({ts}) AND id < {id})"
+                ),
+                ListOrder::Asc => format!(
+                    "({INGESTED_AT_COLUMN} > to_timestamp_micros({ts})) \
+                     OR ({INGESTED_AT_COLUMN} = to_timestamp_micros({ts}) AND id > {id})"
+                ),
+            };
+            scan.filter(&filter)
+                .map_err(|e| FirnflowError::Backend(format!("scan.filter: {e}")))?;
+        }
+
+        let ordering = match order {
+            ListOrder::Desc => vec![
+                ColumnOrdering::desc_nulls_last(INGESTED_AT_COLUMN.to_string()),
+                ColumnOrdering::desc_nulls_last("id".to_string()),
+            ],
+            ListOrder::Asc => vec![
+                ColumnOrdering::asc_nulls_first(INGESTED_AT_COLUMN.to_string()),
+                ColumnOrdering::asc_nulls_first("id".to_string()),
+            ],
+        };
+        scan.order_by(Some(ordering))
+            .map_err(|e| FirnflowError::Backend(format!("scan.order_by: {e}")))?;
+
+        // Pull `limit + 1` so we can derive the next cursor and
+        // flag "no more pages" in one pass.
+        scan.limit(Some((limit + 1) as i64), None)
+            .map_err(|e| FirnflowError::Backend(format!("scan.limit: {e}")))?;
+
+        let stream = scan
+            .try_into_stream()
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("scan.try_into_stream: {e}")))?;
+        let batches: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("scan.collect: {e}")))?;
+
+        let mut rows = batches_to_list_rows(&batches)?;
+
+        let next_cursor = if rows.len() > limit {
+            rows.truncate(limit);
+            rows.last()
+                .map(|r| encode_list_cursor(r.ingested_at_micros, r.id))
+        } else {
+            None
+        };
+
+        Ok(ListPage { rows, next_cursor })
+    }
+}
+
+/// Encode a `(timestamp_micros, id)` pair as a 32-character hex
+/// cursor. Opaque on the wire; the handler round-trips it via
+/// [`decode_list_cursor`].
+pub fn encode_list_cursor(ts_micros: i64, id: u64) -> String {
+    format!("{:016x}{:016x}", ts_micros as u64, id)
+}
+
+/// Decode a cursor produced by [`encode_list_cursor`]. Returns an
+/// [`FirnflowError::InvalidRequest`] on malformed input so the API
+/// layer can return a 400 verbatim.
+pub fn decode_list_cursor(cursor: &str) -> Result<(i64, u64), FirnflowError> {
+    if cursor.len() != 32 || !cursor.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(FirnflowError::InvalidRequest(format!(
+            "malformed cursor {cursor:?}: expected 32 hex characters"
+        )));
+    }
+    let ts = u64::from_str_radix(&cursor[..16], 16)
+        .map_err(|e| FirnflowError::InvalidRequest(format!("cursor timestamp: {e}")))?;
+    let id = u64::from_str_radix(&cursor[16..], 16)
+        .map_err(|e| FirnflowError::InvalidRequest(format!("cursor id: {e}")))?;
+    Ok((ts as i64, id))
 }
 
 /// Result of a compaction operation, exposing the fragment delta.
@@ -617,29 +828,62 @@ pub struct CompactResult {
     pub fragments_added: usize,
 }
 
-/// Read the vector dimension from a Lance table's schema by
-/// inspecting the `FixedSizeList.list_size` of the `vector` column.
-async fn read_dim_from_table(tbl: &lancedb::Table) -> Result<usize, FirnflowError> {
+/// Read the schema facts (vector dimension, `_ingested_at` presence)
+/// from a Lance table in one pass. The dimension comes from the
+/// `FixedSizeList.list_size` of the `vector` column; the flag is set
+/// when a column named `_ingested_at` with a `Timestamp(Microsecond)`
+/// type is present.
+async fn read_schema_info_from_table(
+    tbl: &lancedb::Table,
+) -> Result<NamespaceSchemaInfo, FirnflowError> {
     let schema = tbl
         .schema()
         .await
         .map_err(|e| FirnflowError::Backend(format!("read schema: {e}")))?;
+    let mut dim: Option<usize> = None;
+    let mut has_ingested_at = false;
     for field in schema.fields() {
-        if field.name() == "vector" {
-            if let DataType::FixedSizeList(_, size) = field.data_type() {
-                return Ok(*size as usize);
+        match field.name().as_str() {
+            "vector" => {
+                if let DataType::FixedSizeList(_, size) = field.data_type() {
+                    dim = Some(*size as usize);
+                }
             }
+            INGESTED_AT_COLUMN => {
+                if matches!(
+                    field.data_type(),
+                    DataType::Timestamp(TimeUnit::Microsecond, _)
+                ) {
+                    has_ingested_at = true;
+                }
+            }
+            _ => {}
         }
     }
-    Err(FirnflowError::Backend(
-        "table schema has no FixedSizeList 'vector' column".into(),
-    ))
+    let dim = dim.ok_or_else(|| {
+        FirnflowError::Backend("table schema has no FixedSizeList 'vector' column".into())
+    })?;
+    Ok(NamespaceSchemaInfo {
+        dim,
+        has_ingested_at,
+    })
+}
+
+/// Server-clock reading in microseconds since the Unix epoch.
+/// Negative clock skew or pre-epoch system clocks are clamped to 0 —
+/// the column is a write-time stamp, not a system clock health check.
+fn current_micros() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros() as i64)
+        .unwrap_or(0)
 }
 
 fn rows_to_batch(
     schema: &Arc<Schema>,
     dim: usize,
     rows: Vec<UpsertRow>,
+    include_ingested_at: bool,
 ) -> Result<RecordBatch, FirnflowError> {
     let n = rows.len();
     let ids = UInt64Array::from_iter_values(rows.iter().map(|r| r.id));
@@ -663,15 +907,24 @@ fn rows_to_batch(
     }
     let texts = text_builder.finish();
 
-    RecordBatch::try_new(
-        schema.clone(),
-        vec![
-            Arc::new(ids) as ArrayRef,
-            Arc::new(vectors) as ArrayRef,
-            Arc::new(texts) as ArrayRef,
-        ],
-    )
-    .map_err(|e| FirnflowError::Backend(format!("batch build: {e}")))
+    let mut columns: Vec<ArrayRef> = vec![
+        Arc::new(ids) as ArrayRef,
+        Arc::new(vectors) as ArrayRef,
+        Arc::new(texts) as ArrayRef,
+    ];
+
+    if include_ingested_at {
+        // Stamp every row in the batch with the same server-side
+        // timestamp. Because Lance appends are immutable, this
+        // becomes the row's permanent "arrival" time — first-write
+        // semantics fall out of the append-only model for free.
+        let ts = current_micros();
+        let ts_array = TimestampMicrosecondArray::from_iter_values(std::iter::repeat_n(ts, n));
+        columns.push(Arc::new(ts_array) as ArrayRef);
+    }
+
+    RecordBatch::try_new(schema.clone(), columns)
+        .map_err(|e| FirnflowError::Backend(format!("batch build: {e}")))
 }
 
 /// Find the score column in a result batch. Lance uses different
@@ -688,6 +941,58 @@ fn find_score_column(batch: &RecordBatch) -> Option<&Float32Array> {
         }
     }
     None
+}
+
+fn batches_to_list_rows(batches: &[RecordBatch]) -> Result<Vec<ListRow>, FirnflowError> {
+    let mut out = Vec::new();
+    for batch in batches {
+        let ids = batch
+            .column_by_name("id")
+            .ok_or_else(|| FirnflowError::Backend("list: missing id column".into()))?
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| FirnflowError::Backend("list: id not UInt64".into()))?;
+        let vectors = batch
+            .column_by_name("vector")
+            .ok_or_else(|| FirnflowError::Backend("list: missing vector column".into()))?
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .ok_or_else(|| FirnflowError::Backend("list: vector not FixedSizeList".into()))?;
+        let texts = batch
+            .column_by_name("text")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+        let ingested_at = batch
+            .column_by_name(INGESTED_AT_COLUMN)
+            .ok_or_else(|| FirnflowError::Backend("list: missing _ingested_at column".into()))?
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .ok_or_else(|| {
+                FirnflowError::Backend("list: _ingested_at not Timestamp(Microsecond)".into())
+            })?;
+
+        for row in 0..batch.num_rows() {
+            let vector_arr = vectors.value(row);
+            let vec_f32 = vector_arr
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| FirnflowError::Backend("list: vector inner not Float32".into()))?;
+            let vector: Vec<f32> = (0..vec_f32.len()).map(|i| vec_f32.value(i)).collect();
+            let text = texts.and_then(|t| {
+                if t.is_null(row) {
+                    None
+                } else {
+                    Some(t.value(row).to_owned())
+                }
+            });
+            out.push(ListRow {
+                id: ids.value(row),
+                vector,
+                text,
+                ingested_at_micros: ingested_at.value(row),
+            });
+        }
+    }
+    Ok(out)
 }
 
 fn batches_to_results(batches: &[RecordBatch]) -> Result<Vec<QueryResult>, FirnflowError> {
@@ -744,4 +1049,36 @@ fn batches_to_results(batches: &[RecordBatch]) -> Result<Vec<QueryResult>, Firnf
         }
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_round_trip() {
+        for (ts, id) in [
+            (0_i64, 0_u64),
+            (1, 1),
+            (i64::MAX, u64::MAX),
+            (1_700_000_000_000_000, 42),
+        ] {
+            let encoded = encode_list_cursor(ts, id);
+            assert_eq!(encoded.len(), 32);
+            let (ts2, id2) = decode_list_cursor(&encoded).expect("decode");
+            assert_eq!((ts, id), (ts2, id2));
+        }
+    }
+
+    #[test]
+    fn cursor_rejects_bad_length() {
+        assert!(decode_list_cursor("").is_err());
+        assert!(decode_list_cursor("abcd").is_err());
+        assert!(decode_list_cursor(&"a".repeat(33)).is_err());
+    }
+
+    #[test]
+    fn cursor_rejects_non_hex() {
+        assert!(decode_list_cursor(&"z".repeat(32)).is_err());
+    }
 }

--- a/crates/firnflow-core/src/result.rs
+++ b/crates/firnflow-core/src/result.rs
@@ -37,3 +37,44 @@ pub struct QueryResultSet {
     /// Search hits, already ranked by the underlying engine.
     pub results: Vec<QueryResult>,
 }
+
+/// Sort order for the `list` endpoint. Descending returns newest
+/// rows first and is the intended default for "recent content" flows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ListOrder {
+    /// Oldest first.
+    Asc,
+    /// Newest first.
+    Desc,
+}
+
+/// A single row returned by the list endpoint. Deliberately distinct
+/// from [`QueryResult`] — there is no score (the endpoint does not
+/// rank by similarity) and there is an ingest timestamp.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ListRow {
+    /// Stable row id from the underlying Lance table.
+    pub id: u64,
+    /// The stored vector for this row. Width matches the
+    /// namespace's dimension.
+    pub vector: Vec<f32>,
+    /// The stored text for this row, if any.
+    #[serde(default)]
+    pub text: Option<String>,
+    /// Server-side timestamp (microseconds since Unix epoch) the
+    /// row was first written. Immutable for the life of the row —
+    /// Lance appends never rewrite it.
+    pub ingested_at_micros: i64,
+}
+
+/// A page of list results plus an opaque cursor for the next page.
+/// `next_cursor` is `None` when the server returned the final page.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ListPage {
+    /// Rows in the requested order.
+    pub rows: Vec<ListRow>,
+    /// Opaque cursor to pass as `?cursor=` on the next call, or
+    /// `None` if no further rows are available in the chosen order.
+    pub next_cursor: Option<String>,
+}

--- a/crates/firnflow-core/tests/manager_list.rs
+++ b/crates/firnflow-core/tests/manager_list.rs
@@ -1,0 +1,188 @@
+//! Integration test for `NamespaceManager::list` (issue #22).
+//!
+//! Appends several batches of rows to a fresh namespace with small
+//! sleeps between them so each batch gets a distinct server-side
+//! `_ingested_at` timestamp. Pages through the namespace with a
+//! small `limit` so pagination boundaries are forced to fall inside
+//! and across batches, then asserts:
+//!
+//! - every id 0..N shows up exactly once,
+//! - the concatenated page stream is strictly ordered by
+//!   `(_ingested_at DESC, id DESC)` (in-batch ties are broken by id),
+//! - the final page returns `next_cursor: None`.
+//!
+//! Gated `#[ignore]`: needs MinIO up.
+//!
+//! ```text
+//! docker compose up -d minio minio-init
+//! ./scripts/cargo test -p firnflow-core --test manager_list \
+//!     -- --ignored --nocapture
+//! ```
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::time::Duration;
+
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{
+    decode_list_cursor, ListOrder, ListRow, NamespaceId, NamespaceManager, UpsertRow,
+};
+
+const DIM: usize = 4;
+const BATCHES: usize = 5;
+const ROWS_PER_BATCH: usize = 10;
+const PAGE_LIMIT: usize = 7;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn unique_namespace(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "aws_access_key_id".into(),
+            env_or("FIRNFLOW_S3_ACCESS_KEY", "minioadmin"),
+        ),
+        (
+            "aws_secret_access_key".into(),
+            env_or("FIRNFLOW_S3_SECRET_KEY", "minioadmin"),
+        ),
+        (
+            "aws_endpoint".into(),
+            env_or("FIRNFLOW_S3_ENDPOINT", "http://127.0.0.1:9000"),
+        ),
+        ("aws_region".into(), "us-east-1".into()),
+        ("allow_http".into(), "true".into()),
+        ("aws_virtual_hosted_style_request".into(), "false".into()),
+    ])
+}
+
+fn unit_vector(axis: usize) -> Vec<f32> {
+    let mut v = vec![0.0_f32; DIM];
+    v[axis % DIM] = 1.0;
+    v
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_paginates_in_strict_ingest_order() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
+    let ns = NamespaceId::new(unique_namespace("issue22")).unwrap();
+
+    // Seed `BATCHES` separated batches so each batch gets a distinct
+    // `_ingested_at` timestamp. The sleep must exceed the clock
+    // resolution we stamp at (microseconds) — 5ms is more than enough
+    // while keeping the test quick.
+    let mut expected_ids: Vec<u64> = Vec::new();
+    for batch_idx in 0..BATCHES {
+        let base = (batch_idx * ROWS_PER_BATCH) as u64;
+        let rows: Vec<UpsertRow> = (0..ROWS_PER_BATCH)
+            .map(|i| (base + i as u64, unit_vector(i)).into())
+            .collect();
+        for row in &rows {
+            expected_ids.push(row.id);
+        }
+        manager.upsert(&ns, rows).await.expect("upsert batch");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    let total = expected_ids.len();
+
+    // Page through the namespace in descending order.
+    let mut collected: Vec<ListRow> = Vec::new();
+    let mut cursor: Option<(i64, u64)> = None;
+    loop {
+        let page = manager
+            .list(&ns, PAGE_LIMIT, ListOrder::Desc, cursor)
+            .await
+            .expect("list page");
+        assert!(
+            page.rows.len() <= PAGE_LIMIT,
+            "page returned {} rows, expected <= {PAGE_LIMIT}",
+            page.rows.len()
+        );
+        collected.extend(page.rows);
+        match page.next_cursor {
+            Some(c) => {
+                cursor = Some(decode_list_cursor(&c).expect("decode returned cursor"));
+            }
+            None => break,
+        }
+    }
+
+    assert_eq!(
+        collected.len(),
+        total,
+        "paginated total ({}) != upserted total ({total})",
+        collected.len()
+    );
+    let seen: HashSet<u64> = collected.iter().map(|r| r.id).collect();
+    assert_eq!(
+        seen.len(),
+        total,
+        "ids collected across pages must be unique"
+    );
+    for id in &expected_ids {
+        assert!(seen.contains(id), "id {id} missing from list output");
+    }
+
+    // Strict descending order on (ingested_at, id). In-batch rows
+    // share an `_ingested_at`; the secondary id-desc tiebreak must
+    // keep them stable and monotonically decreasing.
+    for window in collected.windows(2) {
+        let (a, b) = (&window[0], &window[1]);
+        let a_key = (a.ingested_at_micros, a.id);
+        let b_key = (b.ingested_at_micros, b.id);
+        assert!(
+            a_key > b_key,
+            "ordering violated at page boundary: {a_key:?} should be > {b_key:?}"
+        );
+    }
+
+    // Ascending pass — verify the endpoint's symmetric behaviour.
+    let mut asc_collected: Vec<ListRow> = Vec::new();
+    let mut cursor: Option<(i64, u64)> = None;
+    loop {
+        let page = manager
+            .list(&ns, PAGE_LIMIT, ListOrder::Asc, cursor)
+            .await
+            .expect("list page (asc)");
+        asc_collected.extend(page.rows);
+        match page.next_cursor {
+            Some(c) => cursor = Some(decode_list_cursor(&c).unwrap()),
+            None => break,
+        }
+    }
+    assert_eq!(asc_collected.len(), total);
+    for window in asc_collected.windows(2) {
+        let a_key = (window[0].ingested_at_micros, window[0].id);
+        let b_key = (window[1].ingested_at_micros, window[1].id);
+        assert!(
+            a_key < b_key,
+            "ascending order violated: {a_key:?} must be < {b_key:?}"
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_empty_namespace_returns_empty_page() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
+    let ns = NamespaceId::new(unique_namespace("issue22-empty")).unwrap();
+
+    let page = manager
+        .list(&ns, 50, ListOrder::Desc, None)
+        .await
+        .expect("list on fresh namespace must not error");
+    assert!(page.rows.is_empty());
+    assert!(page.next_cursor.is_none());
+}

--- a/docs/api.html
+++ b/docs/api.html
@@ -202,6 +202,60 @@
       </div>
     </div>
 
+    <!-- GET /ns/{ns}/list -->
+    <div class="endpoint">
+      <div class="endpoint-header" aria-expanded="true">
+        <span class="method method-get">GET</span>
+        <span class="endpoint-path">/ns/{namespace}/list</span>
+        <span class="endpoint-desc">Cursor-paginated list ordered by <code>_ingested_at</code></span>
+      </div>
+      <div class="endpoint-body">
+        <p>Returns rows in ingest order for "recent content" flows (landing pages, new-uploads feeds, back-catalogue browsing). Results are ordered by the reserved <code>_ingested_at</code> system column (microsecond server-side timestamp, set at first write and never mutated).</p>
+        <p>This endpoint intentionally bypasses the foyer cache. Pagination tails would push hot query results out of RAM and NVMe without an offsetting hit rate, so <code>/list</code> goes directly to the Lance dataset.</p>
+
+        <h4>Query parameters</h4>
+        <table>
+          <thead><tr><th>Param</th><th>Default</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>order_by</code></td><td><code>_ingested_at</code></td><td>V1 supports the reserved system column only; other values return 400. User-column ordering will follow scalar-index support.</td></tr>
+            <tr><td><code>order</code></td><td><code>desc</code></td><td><code>asc</code> or <code>desc</code>.</td></tr>
+            <tr><td><code>limit</code></td><td>50</td><td>Rows per page. Hard-capped at 500.</td></tr>
+            <tr><td><code>cursor</code></td><td>none</td><td>Opaque token from the previous response's <code>next_cursor</code>. Value-based, survives concurrent writes. Format is implementation-defined — do not parse or construct by hand.</td></tr>
+          </tbody>
+        </table>
+
+        <h4>Response (200)</h4>
+        <table>
+          <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>rows</code></td><td>array</td><td>Rows in the requested order</td></tr>
+            <tr><td><code>rows[].id</code></td><td>u64</td><td>Row identifier</td></tr>
+            <tr><td><code>rows[].vector</code></td><td>float32[]</td><td>The stored vector</td></tr>
+            <tr><td><code>rows[].text</code></td><td>string?</td><td>The stored text (null if none)</td></tr>
+            <tr><td><code>rows[].ingested_at_micros</code></td><td>i64</td><td>Server-side microsecond timestamp the row was first written</td></tr>
+            <tr><td><code>next_cursor</code></td><td>string?</td><td>Pass verbatim as <code>?cursor=</code> on the next call; <code>null</code> on the final page</td></tr>
+          </tbody>
+        </table>
+
+        <h4>Status codes</h4>
+        <table>
+          <thead><tr><th>Code</th><th>When</th></tr></thead>
+          <tbody>
+            <tr><td>200</td><td>Success</td></tr>
+            <tr><td>400</td><td>Invalid <code>order_by</code>, malformed <code>cursor</code>, or <code>limit</code> over 500</td></tr>
+            <tr><td>501</td><td>Namespace's Lance table pre-dates the <code>_ingested_at</code> column; recreate the namespace to enable the endpoint</td></tr>
+          </tbody>
+        </table>
+
+        <h4>Examples</h4>
+        <p>First page, newest first:</p>
+        <pre><code>curl 'http://localhost:3000/ns/demo/list?limit=50'</code></pre>
+
+        <p>Next page via cursor:</p>
+        <pre><code>curl 'http://localhost:3000/ns/demo/list?limit=50&amp;cursor=0006012a9abb9c800000000000000007'</code></pre>
+      </div>
+    </div>
+
     <!-- DELETE /ns/{ns} -->
     <div class="endpoint">
       <div class="endpoint-header" aria-expanded="true">


### PR DESCRIPTION
Closes #22

## Summary
- New `GET /ns/{namespace}/list` endpoint, cursor-paginated, ordered by a new reserved `_ingested_at` system column.
- Bypasses the foyer cache so pagination tails do not pollute hot query entries — handler calls `NamespaceManager::list` directly.
- V1 supports `order_by=_ingested_at` only; user-column ordering lands once scalar indexes are a first-class feature.

## What changed
- `_ingested_at` (`Timestamp(Microsecond, None)`) added to the namespace schema, auto-populated at batch build time. First-write-only semantics fall out of the append-only model.
- `NamespaceManager::list` drops through to `lance::Dataset::scan()` with `order_by` + cursor filter (LanceDB 0.27's high-level query has no ordering pushdown).
- Cursor encoding: 32-char hex of `(timestamp_micros, id)`. Stable across concurrent writes.
- `FirnflowError::Unsupported` → HTTP 501 for pre-upgrade namespaces that lack the column; their upserts continue unchanged.
- `NamespaceManager` now caches `(dim, has_ingested_at)` per namespace in a single `schema_info` map.
- Existing `AppState` gains a `manager` field so the list handler can skip the service/cache path.

## Verification
- `./scripts/cargo fmt --check` and `./scripts/cargo clippy --workspace --all-targets -- -D warnings` clean.
- 11/11 core unit tests pass (including new cursor encode/decode round-trip).
- New integration test `crates/firnflow-core/tests/manager_list.rs`: 5 batches x 10 rows, paginate with `limit=7`, asserts (a) every id present exactly once, (b) strict `(ingested_at DESC, id DESC)` order across page boundaries, (c) symmetric asc pass, (d) empty-namespace path.
- New integration test `crates/firnflow-api/tests/api_list.rs`: happy-path pagination against MinIO, plus 400 on unsupported `order_by`, 400 on malformed cursor, 400 on over-limit, and an explicit cache-bypass assertion (`firnflow_cache_hits_total` / `firnflow_cache_misses_total` unchanged across list calls).
- All pre-existing integration tests (`manager_upsert_query`, `api_smoke`, `api_delete`) still pass against MinIO.

## Known performance note
Without a scalar index on `_ingested_at`, `order_by` triggers a full scan of the fragments matching the cursor filter. Acceptable for small-to-medium namespaces; a scalar index is the follow-up for scale. A hard `limit` cap of 500 bounds per-request cost in the meantime.