### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-18
+
 ### Added
 - `GET /ns/{namespace}/list` — a narrow, cursor-paginated endpoint for "recent content" flows. Ordered by a new reserved system column `_ingested_at` (microsecond timestamp, populated at first write, never mutated). Supports `order_by=_ingested_at` only in v1, `order=asc|desc`, `limit` (default 50, capped at 500), and an opaque hex cursor. Bypasses the foyer cache so pagination tails do not pollute hot query entries (issue #22).
 - `NamespaceManager::list` + `encode_list_cursor` / `decode_list_cursor` helpers. Cursor format is a 32-char hex encoding of `(timestamp_micros, id)` for stable continuation under concurrent writes.
 - `FirnflowError::Unsupported` variant mapped to HTTP 501 for namespaces whose tables pre-date the `_ingested_at` column.
+- `firnflow_s3_requests_total{operation="list"}` is now recorded for every list call so `/list` participates in the cost-visibility story even though it bypasses `NamespaceService`.
 
 ### Changed
 - `NamespaceManager` now caches `(dim, has_ingested_at)` per namespace (`schema_info` replaces the old `dims` DashMap). Existing namespaces without `_ingested_at` continue to accept upserts against their original schema; only the `/list` endpoint rejects them with 501.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,7 +2420,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firnflow-api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-bench"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "firnflow-core",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Release PR for **v0.3.0**.

## Summary
- Bump workspace version 0.2.0 → 0.3.0.
- Promote `[Unreleased]` in CHANGELOG.md under `## [0.3.0] - 2026-04-18`.

## Headline change
`GET /ns/{namespace}/list` ships as a narrow, cursor-paginated endpoint for recent-content flows. Ordered by a new reserved `_ingested_at` system column (set at first write, never mutated). Bypasses the foyer cache so pagination tails do not pollute hot query entries. Full detail in #22 / #23.

## Next steps after merge
- `git tag -a v0.3.0 -m "v0.3.0"` on main and push; `docker-publish.yml` builds and pushes `ghcr.io/gordonmurray/firnflow:0.3.0` + `:latest` automatically on any `v*` tag.
- `gh release create v0.3.0` with notes from the CHANGELOG 0.3.0 section.