### PR TITLE
Promote Tigris to validated after upstream CAS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Tigris is now a validated storage backend. The 2026-04-17 concurrent-stress failure (silent write loss under contention on both dual-region and single-region buckets) was fixed upstream. A 2026-04-19 re-run of the 100-iteration stress passed cleanly on both `firn-tigris-bucket` (dual-region, 375 s) and `firn-tigris-single-region` (291 s). The README compatibility matrix and `notes/providers/tigris.md` are updated; the original failure record is preserved in the provider writeup for provenance.
+
 ## [0.3.0] - 2026-04-18
 
 ### Added
@@ -79,6 +82,7 @@ development through phases 1 through 8 before being made public;
   benchmark at dim=1536, 100k rows available at
   `bench/results/cold_vs_warm_aws.md`.
 
-[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/gordonmurray/firnflow/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gordonmurray/firnflow/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/gordonmurray/firnflow/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Firn
 
-**Firn** is a high-performance, multi-tenant vector and full-text search engine backed by object storage (AWS S3, MinIO, Cloudflare R2). It is designed as a credible open-source alternative to turbopuffer, proving that a professional-grade tiered storage architecture (**RAM → NVMe → S3**) is achievable entirely from open-source components. See [Storage backends](#storage-backends) for the full compatibility matrix.
+**Firn** is a high-performance, multi-tenant vector and full-text search engine backed by object storage (AWS S3, MinIO, Cloudflare R2, Tigris). It is designed as a credible open-source alternative to turbopuffer, proving that a professional-grade tiered storage architecture (**RAM → NVMe → S3**) is achievable entirely from open-source components. See [Storage backends](#storage-backends) for the full compatibility matrix.
 
 The cost efficiency of S3 with the speed of local RAM. A multi-tenant vector and full-text search engine backed by S3. Built with LanceDB and Foyer for microsecond-scale search latency on top of object storage.
 
@@ -45,7 +45,7 @@ Firn's correctness depends on S3's `If-None-Match: *` precondition behaving as a
 | **MinIO** (self-hosted / local) | ✅ | Reference implementation for the S3 protocol; clean pass on 100-run stress. |
 | **Cloudflare R2** | ✅ | `If-None-Match: *` honoured correctly; 100-run stress clean. Per-iteration latency is roughly 7x AWS due to R2's multi-region commit path, but correctness is what the gate checks. Zero egress makes this the most interesting non-AWS target. Use path-style addressing. |
 | **Backblaze B2** (S3 compat layer) | ❌ | Returns `HTTP 501 NotImplemented` on the first PutObject with `If-None-Match: *`. B2's native API supports conditional writes via `X-Bz-*` headers, but the S3-compat gateway does not translate them. Loud failure: easy to detect, not usable for Firn. |
-| **Tigris** (dual-region + single-region) | ❌ | Passes the sequential pre-flight but loses whole writer batches under concurrent stress. Dual-region: 0/6 runs clean. Single-region: 3/10 runs clean, 7/10 lost 1 to 3 writers. CAS primitive is not strictly linearisable even within a single region. |
+| **Tigris** (dual-region + single-region) | ✅ | `If-None-Match: *` honoured on concurrent commits; 100-run stress clean on both dual-region and single-region buckets as of 2026-04-19 after an upstream CAS fix. Per-iteration wall time sits between AWS `eu-west-1` and Cloudflare R2. The original 2026-04-17 failure (silent write loss under concurrency) is preserved in `notes/providers/tigris.md` for provenance. Use path-style addressing on `t3.storage.dev`. |
 | **Google Cloud Storage** (via S3 interop) | ❌ | Silently ignores `If-None-Match: *`: the second conditional PUT returns `200 OK` instead of `412`. Concurrent stress loses 6/8 writers every run, deterministically. GCS's native `x-goog-if-generation-match: 0` works correctly; only the S3-interop translation is broken. A future release could support GCS via LanceDB's native GCS backend rather than the S3 layer. |
 
 The two dedicated tests live at `crates/firnflow-core/tests/s3_conditional_writes.rs` and `crates/firnflow-core/tests/lance_concurrent_writes.rs`. Both are `#[ignore]`'d and require credentials to run. If you want to evaluate a backend not in the table, copy a block from either file and point it at your own bucket.


### PR DESCRIPTION
## Summary

Tigris shipped a fix for the non-linearisable `If-None-Match: *` CAS behaviour that caused silent write loss on the 2026-04-17 stress runs. The 100-run concurrent-writer harness now passes cleanly on both the dual-region bucket (`firn-tigris-bucket`) and the single-region bucket (`firn-tigris-single-region`), clearing the same bar MinIO and AWS S3 cleared.

## What changed

- `README.md` — compatibility matrix row flipped from ❌ to ✅, Tigris added to the backend list in the opening paragraph.
- `CHANGELOG.md` — `[Unreleased]` entry under `### Changed`. Also fixed the `[Unreleased]` comparison link to point from `v0.3.0` instead of the stale `v0.2.0` and added the missing `[0.3.0]` link that had not been added at release time.

## Verification

Re-ran the existing harness at `crates/firnflow-core/tests/lance_concurrent_writes.rs` against both bucket configurations — no test-code changes.

| Bucket | 100-run stress | Wall time |
| --- | --- | --- |
| `firn-tigris-bucket` (dual-region) | 100/100 clean | 375.02 s |
| `firn-tigris-single-region` | 100/100 clean | 291.68 s |

Per-iteration wall time sits between AWS `eu-west-1` (~3.37 s) and Cloudflare R2 (~23.5 s). The original 2026-04-17 failure record (0/6 clean dual-region, 3/10 clean single-region) is preserved in `notes/providers/tigris.md` for the decision trail.