### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-02
+
 ### Added
 - `POST /ns/{namespace}/scalar-index` — builds a BTree scalar index on the reserved `_ingested_at` column asynchronously (returns 202 Accepted). With the index in place, `/list` cursor pages do an index range scan instead of a full-fragment scan and the leading `ORDER BY _ingested_at` short-circuits the in-memory sort. The build runs in a tokio task and reports duration via `firnflow_index_build_duration_seconds{kind="scalar"}`. Idempotent (repeat calls rebuild in place); the cached connection/table handle is evicted on success in line with the existing manifest-bump rationale used by `/index` and `/fts-index`. `POST /compact` already runs `optimize_indices` after the file compaction step, so the BTree absorbs new rows incrementally — no separate rebuild trigger is needed after compaction. Closes #24.
 - DigitalOcean Spaces is a validated storage backend. The `If-None-Match: *` pre-flight returns 412 on the second PUT and a 100-iteration concurrent-writer stress run produced 800/800 rows on every iteration with zero discrepancies, validated against `firn-sample-bucket` in the London (`lon1`) region. Per-iteration wall time is ~3.10 s, the same performance class as AWS `eu-west-1` and the fastest non-AWS backend tested. The README compatibility matrix is updated; deployment requires the regional endpoint (`https://<region>.digitaloceanspaces.com`) and path-style addressing, the same client-side quirk that affects Cloudflare R2 and Tigris on `object_store` 0.12. Test functions live alongside the existing per-provider blocks in `crates/firnflow-core/tests/s3_conditional_writes.rs` and `crates/firnflow-core/tests/lance_concurrent_writes.rs`. Closes #29.
@@ -86,7 +88,8 @@ development through phases 1 through 8 before being made public;
   benchmark at dim=1536, 100k rows available at
   `bench/results/cold_vs_warm_aws.md`.
 
-[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/gordonmurray/firnflow/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gordonmurray/firnflow/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gordonmurray/firnflow/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/gordonmurray/firnflow/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,7 +2420,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firnflow-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-bench"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "firnflow-core",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Release PR for **v0.4.0**.

## Summary
- Bump workspace version 0.3.0 → 0.4.0.
- Promote `[Unreleased]` in `CHANGELOG.md` under `## [0.4.0] - 2026-05-02`.
- Add the v0.4.0 → v0.3.0 comparison link and re-point `[Unreleased]` at `v0.4.0...HEAD`.

## Headline change
`POST /ns/{namespace}/scalar-index` builds a BTree on the reserved `_ingested_at` column asynchronously and removes the full-fragment scan cost from `/list` cursor pages on large namespaces. Idempotent, evicts the pooled handle on success, and rides on the existing `firnflow_index_build_duration_seconds` histogram with a new `kind="scalar"` series. Closes #24. Full detail in #33.

## Also in this release
- DigitalOcean Spaces validated as a storage backend (100/100 concurrent-stress runs, ~3.10 s per iteration in `lon1`). Closes #29.
- Tigris promoted from ❌ to ✅ in the compatibility matrix after the upstream `If-None-Match: *` CAS fix landed; 100/100 stress clean on both dual-region and single-region buckets.