### PR TITLE
test: stress writer-during-compaction race on Lance

### DIFF
--- a/crates/firnflow-core/tests/lance_concurrent_writes.rs
+++ b/crates/firnflow-core/tests/lance_concurrent_writes.rs
@@ -22,9 +22,11 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use arrow_array::{RecordBatch, RecordBatchIterator, RecordBatchReader, UInt32Array, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
+use lancedb::table::OptimizeAction;
 
 const WRITERS: usize = 8;
 const ROWS_PER_WRITER: usize = 100;
@@ -455,6 +457,294 @@ async fn concurrent_writers_100_runs_gcs() {
         run_stress(uri_base.clone(), opts.clone()).await;
         if run % 10 == 0 {
             eprintln!("gcs run {run}/{RUNS} passed");
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Writer-during-compaction race (OSWALD-flavour).
+//
+// OSWALD (https://nvartolomei.com/oswald) proves that PUT-If-None-Match
+// alone is insufficient when garbage collection (compaction) is active:
+// a write may succeed from the writer's perspective and yet be absent
+// from the post-compaction state. SlateDB hit this exact bug in May
+// 2026; whether Lance's commit protocol handles it cleanly on top of
+// S3 is the question this test answers.
+//
+// Shape: identical to `run_stress` (8 writers × 100 rows on a fresh
+// namespace) plus a single compactor task that loops `OptimizeAction`
+// while the writers race to append. After all writers finish, the
+// compactor is signalled to stop and the row count is verified. A
+// row count below 800 is the OSWALD-flavour failure mode — silent
+// loss, the dangerous shape. A panic from the compactor or a writer
+// would be a different (safer) outcome and is allowed to propagate.
+// -----------------------------------------------------------------------------
+
+async fn run_stress_with_compaction(uri_base: String, opts: HashMap<String, String>) {
+    let ns = unique_namespace("oswald");
+    let uri = format!("{uri_base}/{ns}");
+    let schema = schema();
+
+    // Seed the table with an empty batch so the schema is registered
+    // and the first compaction has something to operate on.
+    let initial = empty_batch(schema.clone());
+    let reader: Box<dyn RecordBatchReader + Send> =
+        Box::new(RecordBatchIterator::new(vec![Ok(initial)], schema.clone()));
+    let conn = connect(&uri, &opts).await;
+    conn.create_table(TABLE, reader)
+        .execute()
+        .await
+        .expect("create_table");
+
+    // Compactor task: loops OptimizeAction::default() (== Compact) until
+    // signalled to stop. Errors are swallowed because a commit-conflict
+    // bubbling up to the operator is *safe* behaviour — it's only silent
+    // row loss in the final count that proves the OSWALD bug.
+    let stop = Arc::new(AtomicBool::new(false));
+    let compactor = {
+        let uri = uri.clone();
+        let opts = opts.clone();
+        let stop = Arc::clone(&stop);
+        tokio::spawn(async move {
+            let mut iterations = 0usize;
+            let mut errors = 0usize;
+            while !stop.load(Ordering::Relaxed) {
+                let conn = connect(&uri, &opts).await;
+                let tbl = match conn.open_table(TABLE).execute().await {
+                    Ok(t) => t,
+                    Err(_) => {
+                        errors += 1;
+                        continue;
+                    }
+                };
+                match tbl.optimize(OptimizeAction::default()).await {
+                    Ok(_) => iterations += 1,
+                    Err(_) => errors += 1,
+                }
+            }
+            (iterations, errors)
+        })
+    };
+
+    // Spawn N writers, identical to run_stress. Each re-opens the
+    // connection so the CAS contention is real, not faked through
+    // shared in-process state.
+    let mut handles = Vec::with_capacity(WRITERS);
+    for writer_id in 0..WRITERS {
+        let uri = uri.clone();
+        let opts = opts.clone();
+        let schema = schema.clone();
+        handles.push(tokio::spawn(async move {
+            let conn = connect(&uri, &opts).await;
+            let tbl = conn.open_table(TABLE).execute().await.expect("open_table");
+            let batch = writer_batch(schema.clone(), writer_id as u32, ROWS_PER_WRITER);
+            let reader: Box<dyn RecordBatchReader + Send> =
+                Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema));
+            tbl.add(reader).execute().await.expect("table.add");
+        }));
+    }
+    for h in handles {
+        h.await.expect("writer task panicked");
+    }
+
+    // Signal the compactor and wait for it to finish its in-flight
+    // iteration. We capture the (iterations, errors) tuple so the
+    // test output makes it obvious whether the compactor actually
+    // ran during the writer window.
+    stop.store(true, Ordering::Relaxed);
+    let (iterations, errors) = compactor.await.expect("compactor task panicked");
+    eprintln!(
+        "compactor finished: {iterations} successful optimize calls, {errors} errors"
+    );
+
+    let conn = connect(&uri, &opts).await;
+    let tbl = conn.open_table(TABLE).execute().await.expect("open_table");
+    let count = tbl.count_rows(None).await.expect("count_rows");
+    let expected = WRITERS * ROWS_PER_WRITER;
+    assert_eq!(
+        count, expected,
+        "writer-during-compaction stress on {uri}: expected {expected} rows, got {count}. \
+         Lance's commit protocol lost writes when compaction ran concurrently — this is \
+         the OSWALD-flavour writer/GC race (compactor ran {iterations} times, {errors} errors)."
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn concurrent_writes_during_compaction_minio() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let uri_base = format!("s3://{bucket}");
+    run_stress_with_compaction(uri_base, minio_storage_options()).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn concurrent_writes_during_compaction_aws() {
+    if std::env::var("AWS_PROFILE").is_err() {
+        eprintln!("SKIP: AWS_PROFILE not set; real-AWS OSWALD race test needs a configured CLI profile");
+        return;
+    }
+    let bucket = env_or("FIRNFLOW_AWS_BUCKET", "firnflow-cloudfloe");
+    let uri_base = format!("s3://{bucket}");
+    run_stress_with_compaction(uri_base, aws_storage_options()).await;
+}
+
+/// 50-iteration regression guard. Run once a clean / failing single-shot
+/// result has been established; deterministic loss (every iteration
+/// failing identically) is conclusive after even one run, but a flaky
+/// race may only surface intermittently. Mirrors the existing 100-run
+/// stress tests.
+#[tokio::test]
+#[ignore]
+async fn concurrent_writes_during_compaction_50_runs_minio() {
+    const RUNS: usize = 50;
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let uri_base = format!("s3://{bucket}");
+    let opts = minio_storage_options();
+    for run in 1..=RUNS {
+        run_stress_with_compaction(uri_base.clone(), opts.clone()).await;
+        eprintln!("oswald minio run {run}/{RUNS} passed");
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Aggressive writer-during-compaction variant.
+//
+// The standard variant (8 writers × 1 batch × 100 rows) gives the
+// compactor only 8 writer-side manifest commits to race against. That
+// passed 50/50 on MinIO, but a short writer window is the easiest case
+// to handle correctly — the OSWALD bug is most likely to surface when
+// many writers each commit several times in a row, multiplying the
+// chance that a compactor lands its manifest rewrite between a writer
+// reading the current manifest and writing back its CAS.
+//
+// This variant runs 16 writers × 4 sequential appends × 25 rows = 1600
+// total rows, with the same single compactor looping `OptimizeAction::All`.
+// 64 writer commits per iteration vs. 8 in the standard test.
+// -----------------------------------------------------------------------------
+
+const AGG_WRITERS: usize = 16;
+const AGG_BATCHES_PER_WRITER: usize = 4;
+const AGG_ROWS_PER_BATCH: usize = 25;
+
+async fn run_stress_with_compaction_aggressive(
+    uri_base: String,
+    opts: HashMap<String, String>,
+) {
+    let ns = unique_namespace("oswald-agg");
+    let uri = format!("{uri_base}/{ns}");
+    let schema = schema();
+
+    let initial = empty_batch(schema.clone());
+    let reader: Box<dyn RecordBatchReader + Send> =
+        Box::new(RecordBatchIterator::new(vec![Ok(initial)], schema.clone()));
+    let conn = connect(&uri, &opts).await;
+    conn.create_table(TABLE, reader)
+        .execute()
+        .await
+        .expect("create_table");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let compactor = {
+        let uri = uri.clone();
+        let opts = opts.clone();
+        let stop = Arc::clone(&stop);
+        tokio::spawn(async move {
+            let mut iterations = 0usize;
+            let mut errors = 0usize;
+            while !stop.load(Ordering::Relaxed) {
+                let conn = connect(&uri, &opts).await;
+                let tbl = match conn.open_table(TABLE).execute().await {
+                    Ok(t) => t,
+                    Err(_) => {
+                        errors += 1;
+                        continue;
+                    }
+                };
+                match tbl.optimize(OptimizeAction::default()).await {
+                    Ok(_) => iterations += 1,
+                    Err(_) => errors += 1,
+                }
+            }
+            (iterations, errors)
+        })
+    };
+
+    let mut handles = Vec::with_capacity(AGG_WRITERS);
+    for writer_id in 0..AGG_WRITERS {
+        let uri = uri.clone();
+        let opts = opts.clone();
+        let schema = schema.clone();
+        handles.push(tokio::spawn(async move {
+            let conn = connect(&uri, &opts).await;
+            let tbl = conn.open_table(TABLE).execute().await.expect("open_table");
+            for batch_idx in 0..AGG_BATCHES_PER_WRITER {
+                // Distinct id range per (writer, batch) so the row
+                // count is the only signal that matters and ids stay
+                // human-readable when introspecting after a failure.
+                let pseudo_writer =
+                    (writer_id * AGG_BATCHES_PER_WRITER + batch_idx) as u32;
+                let batch = writer_batch(schema.clone(), pseudo_writer, AGG_ROWS_PER_BATCH);
+                let reader: Box<dyn RecordBatchReader + Send> = Box::new(
+                    RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+                );
+                tbl.add(reader).execute().await.expect("table.add");
+            }
+        }));
+    }
+    for h in handles {
+        h.await.expect("writer task panicked");
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    let (iterations, errors) = compactor.await.expect("compactor task panicked");
+    eprintln!(
+        "compactor finished (aggressive): {iterations} optimize calls, {errors} errors"
+    );
+
+    let conn = connect(&uri, &opts).await;
+    let tbl = conn.open_table(TABLE).execute().await.expect("open_table");
+    let count = tbl.count_rows(None).await.expect("count_rows");
+    let expected = AGG_WRITERS * AGG_BATCHES_PER_WRITER * AGG_ROWS_PER_BATCH;
+    assert_eq!(
+        count, expected,
+        "aggressive writer-during-compaction stress on {uri}: expected {expected} rows, got {count}. \
+         Lance's commit protocol lost writes when compaction ran concurrently — this is \
+         the OSWALD-flavour writer/GC race (compactor ran {iterations} times, {errors} errors)."
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn concurrent_writes_during_compaction_aggressive_minio() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let uri_base = format!("s3://{bucket}");
+    run_stress_with_compaction_aggressive(uri_base, minio_storage_options()).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn concurrent_writes_during_compaction_aggressive_aws() {
+    if std::env::var("AWS_PROFILE").is_err() {
+        eprintln!("SKIP: AWS_PROFILE not set; AWS aggressive OSWALD race needs a configured CLI profile");
+        return;
+    }
+    let bucket = env_or("FIRNFLOW_AWS_BUCKET", "firnflow-cloudfloe");
+    let uri_base = format!("s3://{bucket}");
+    run_stress_with_compaction_aggressive(uri_base, aws_storage_options()).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn concurrent_writes_during_compaction_aggressive_200_runs_minio() {
+    const RUNS: usize = 200;
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let uri_base = format!("s3://{bucket}");
+    let opts = minio_storage_options();
+    for run in 1..=RUNS {
+        run_stress_with_compaction_aggressive(uri_base.clone(), opts.clone()).await;
+        if run % 10 == 0 {
+            eprintln!("oswald-agg minio run {run}/{RUNS} passed");
         }
     }
 }

--- a/crates/firnflow-core/tests/lance_concurrent_writes.rs
+++ b/crates/firnflow-core/tests/lance_concurrent_writes.rs
@@ -21,8 +21,8 @@
 //! ```
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use arrow_array::{RecordBatch, RecordBatchIterator, RecordBatchReader, UInt32Array, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
@@ -553,9 +553,7 @@ async fn run_stress_with_compaction(uri_base: String, opts: HashMap<String, Stri
     // ran during the writer window.
     stop.store(true, Ordering::Relaxed);
     let (iterations, errors) = compactor.await.expect("compactor task panicked");
-    eprintln!(
-        "compactor finished: {iterations} successful optimize calls, {errors} errors"
-    );
+    eprintln!("compactor finished: {iterations} successful optimize calls, {errors} errors");
 
     let conn = connect(&uri, &opts).await;
     let tbl = conn.open_table(TABLE).execute().await.expect("open_table");
@@ -581,7 +579,9 @@ async fn concurrent_writes_during_compaction_minio() {
 #[ignore]
 async fn concurrent_writes_during_compaction_aws() {
     if std::env::var("AWS_PROFILE").is_err() {
-        eprintln!("SKIP: AWS_PROFILE not set; real-AWS OSWALD race test needs a configured CLI profile");
+        eprintln!(
+            "SKIP: AWS_PROFILE not set; real-AWS OSWALD race test needs a configured CLI profile"
+        );
         return;
     }
     let bucket = env_or("FIRNFLOW_AWS_BUCKET", "firnflow-cloudfloe");
@@ -627,10 +627,7 @@ const AGG_WRITERS: usize = 16;
 const AGG_BATCHES_PER_WRITER: usize = 4;
 const AGG_ROWS_PER_BATCH: usize = 25;
 
-async fn run_stress_with_compaction_aggressive(
-    uri_base: String,
-    opts: HashMap<String, String>,
-) {
+async fn run_stress_with_compaction_aggressive(uri_base: String, opts: HashMap<String, String>) {
     let ns = unique_namespace("oswald-agg");
     let uri = format!("{uri_base}/{ns}");
     let schema = schema();
@@ -682,12 +679,10 @@ async fn run_stress_with_compaction_aggressive(
                 // Distinct id range per (writer, batch) so the row
                 // count is the only signal that matters and ids stay
                 // human-readable when introspecting after a failure.
-                let pseudo_writer =
-                    (writer_id * AGG_BATCHES_PER_WRITER + batch_idx) as u32;
+                let pseudo_writer = (writer_id * AGG_BATCHES_PER_WRITER + batch_idx) as u32;
                 let batch = writer_batch(schema.clone(), pseudo_writer, AGG_ROWS_PER_BATCH);
-                let reader: Box<dyn RecordBatchReader + Send> = Box::new(
-                    RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
-                );
+                let reader: Box<dyn RecordBatchReader + Send> =
+                    Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema.clone()));
                 tbl.add(reader).execute().await.expect("table.add");
             }
         }));
@@ -698,9 +693,7 @@ async fn run_stress_with_compaction_aggressive(
 
     stop.store(true, Ordering::Relaxed);
     let (iterations, errors) = compactor.await.expect("compactor task panicked");
-    eprintln!(
-        "compactor finished (aggressive): {iterations} optimize calls, {errors} errors"
-    );
+    eprintln!("compactor finished (aggressive): {iterations} optimize calls, {errors} errors");
 
     let conn = connect(&uri, &opts).await;
     let tbl = conn.open_table(TABLE).execute().await.expect("open_table");
@@ -726,7 +719,9 @@ async fn concurrent_writes_during_compaction_aggressive_minio() {
 #[ignore]
 async fn concurrent_writes_during_compaction_aggressive_aws() {
     if std::env::var("AWS_PROFILE").is_err() {
-        eprintln!("SKIP: AWS_PROFILE not set; AWS aggressive OSWALD race needs a configured CLI profile");
+        eprintln!(
+            "SKIP: AWS_PROFILE not set; AWS aggressive OSWALD race needs a configured CLI profile"
+        );
         return;
     }
     let bucket = env_or("FIRNFLOW_AWS_BUCKET", "firnflow-cloudfloe");


### PR DESCRIPTION
## Summary

Adds a regression test for the writer-during-compaction race that SlateDB had to fix in [slatedb/slatedb#1622](https://github.com/slatedb/slatedb/issues/1622). The existing concurrent-writer test in `lance_concurrent_writes.rs` covers many writers racing on the same namespace, but never with an active compactor in the mix.

OSWALD (Vartolomei, October 2025) proves that `PUT-If-None-Match` alone is insufficient when garbage collection is active: a write may succeed from the writer's perspective and yet be absent from the post-compaction state. The question this PR answers by running it is whether Lance's CAS-based commit protocol has the same flaw on top of S3.

## What's added

Two variants in `crates/firnflow-core/tests/lance_concurrent_writes.rs`, both gated `#[ignore]` like the existing concurrent-writer tests:

| Test | Shape | Sweep |
| --- | --- | --- |
| `concurrent_writes_during_compaction_*` | 8 writers x 100 rows, plus 1 compactor looping `OptimizeAction::default()` | 50-iteration MinIO sweep |
| `concurrent_writes_during_compaction_aggressive_*` | 16 writers x 4 sequential 25-row appends (64 writer commits), plus the same compactor loop | 200-iteration MinIO sweep |

The aggressive variant exists because the standard shape only gives the compactor 8 writer-side manifest commits per iteration to race against. With 4 sequential appends per writer the writer-commit window is much wider, so the compactor has more opportunities to land its manifest rewrite between a writer reading the current version and writing back its CAS.

Compactor errors are swallowed by design. A commit-conflict surfaced to the operator is safe behaviour; only silent row loss in the final count proves the OSWALD-flavour bug.

## Result on `lance = =4.0.0` / `lancedb = =0.27.2`

| Variant | Iterations | Outcome |
| --- | ---:| --- |
| Standard | 50 | clean, 0 lost rows, ~17 compactions/iteration avg, 0 compactor errors |
| Aggressive | 200 | clean, 0 lost rows, 8,538 successful compactions across the run, 0 errors |

Total rows written without loss across the aggressive sweep: 320,000. Lance's commit retry layer absorbs the manifest-CAS race cleanly for in-process append workloads.

## Out of scope

- **AWS S3 pass.** Deferred to a follow-up. The 200-run MinIO sweep is the primary signal; AWS adds cross-provider confidence but isn't blocking.
- **Distributed compaction.** Lance has a confirmed open bug at [lance-format/lance#6653](https://github.com/lance-format/lance/issues/6653) where a stale OCC `read_version` in distributed compaction can resurrect deleted rows under concurrent DELETE/UPDATE. That requires a planning/execution gap across processes and a non-append workload, neither of which these tests exercise.
- **Failure injection.** No simulated S3 partial-write or killed-mid-commit writer. Happy-path concurrency only.

## Test plan

- [x] `concurrent_writes_during_compaction_minio`, single shot, 800/800
- [x] `concurrent_writes_during_compaction_50_runs_minio`, 50/50
- [x] `concurrent_writes_during_compaction_aggressive_minio`, single shot, 1600/1600
- [x] `concurrent_writes_during_compaction_aggressive_200_runs_minio`, 200/200
- [ ] `concurrent_writes_during_compaction_aws` / `_aggressive_aws`, follow-up