### PR TITLE
Drop internal-only doc references from tracked sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
             protobuf-compiler libprotobuf-dev
 
       # Rust 1.94 matches Dockerfile.dev. rustfmt / clippy must be
-      # installed as components up front — CLAUDE.md calls out that
-      # rustup's proxy misreports them as missing otherwise.
+      # installed as components up front — note that rustup's proxy
+      # misreports them as missing otherwise.
       - name: Install Rust 1.94
         uses: dtolnay/rust-toolchain@master
         with:
@@ -110,7 +110,7 @@ jobs:
       # MinIO-backed integration tests are all gated #[ignore] so the
       # previous step skips them. This step opts them in, minus:
       #   * `_aws` variants — need real AWS credentials, not in CI
-      #   * `_100_runs_*` — spike-2 stress suites, overkill per PR
+      #   * `_100_runs_*` — extended stress suites, overkill per PR
       - name: cargo test (integration, MinIO-backed)
         run: |
           cargo test --workspace --no-fail-fast -- \

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
 /.cargo-cache
-/notes
 *.swp
 .DS_Store
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DigitalOcean Spaces is a validated storage backend. The `If-None-Match: *` pre-flight returns 412 on the second PUT and a 100-iteration concurrent-writer stress run produced 800/800 rows on every iteration with zero discrepancies, validated against `firn-sample-bucket` in the London (`lon1`) region. Per-iteration wall time is ~3.10 s, the same performance class as AWS `eu-west-1` and the fastest non-AWS backend tested. The README compatibility matrix is updated; deployment requires the regional endpoint (`https://<region>.digitaloceanspaces.com`) and path-style addressing, the same client-side quirk that affects Cloudflare R2 and Tigris on `object_store` 0.12. Test functions live alongside the existing per-provider blocks in `crates/firnflow-core/tests/s3_conditional_writes.rs` and `crates/firnflow-core/tests/lance_concurrent_writes.rs`. Closes #29.
 
 ### Changed
-- Tigris is now a validated storage backend. The 2026-04-17 concurrent-stress failure (silent write loss under contention on both dual-region and single-region buckets) was fixed upstream. A 2026-04-19 re-run of the 100-iteration stress passed cleanly on both `firn-tigris-bucket` (dual-region, 375 s) and `firn-tigris-single-region` (291 s). The README compatibility matrix and `notes/providers/tigris.md` are updated; the original failure record is preserved in the provider writeup for provenance.
+- Tigris is now a validated storage backend. The 2026-04-17 concurrent-stress failure (silent write loss under contention on both dual-region and single-region buckets) was fixed upstream. A 2026-04-19 re-run of the 100-iteration stress passed cleanly on both `firn-tigris-bucket` (dual-region, 375 s) and `firn-tigris-single-region` (291 s). The README compatibility matrix is updated.
 
 ## [0.3.0] - 2026-04-18
 
@@ -86,9 +86,9 @@ development through phases 1 through 8 before being made public;
   namespace creation, and full cleanup on delete.
 - Cache-aside read path with after-success invalidation. Keyed on
   `(namespace, generation, query_hash)` using a per-namespace
-  atomic generation counter for O(1) invalidation (ADR-001).
+  atomic generation counter for O(1) invalidation.
 - bincode-2 serialisation path for cached result sets with a
-  100-result p99 round-trip well inside the 1 ms budget (ADR-002).
+  100-result p99 round-trip well inside the 1 ms budget.
 - IVF_PQ vector indexing via `POST /ns/{ns}/index`, BM25 FTS
   indexing via `POST /ns/{ns}/fts-index`, compaction via
   `POST /ns/{ns}/compact`. All three run as non-blocking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 # Vector + FTS search engine on object storage.
-# Pinned exact per CLAUDE.md — bumps are a read-the-changelog event.
+# Pinned exact per project conventions — bumps are a read-the-changelog event.
 # `aws` feature registers the S3 object store provider that lance-io
 # otherwise ships turned off through lancedb's transitive deps.
 lancedb = { version = "=0.27.2", features = ["aws"] }
@@ -73,7 +73,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 thiserror = "2"
 anyhow = "1"
 
-# AWS SDK (used for the spike-2 pre-flight and any direct S3 ops;
+# AWS SDK (used for the conditional-write pre-flight and any direct S3 ops;
 # note lancedb brings its own `object_store`-based S3 client internally).
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }

--- a/bench/results/cold_vs_warm.md
+++ b/bench/results/cold_vs_warm.md
@@ -1,4 +1,4 @@
-# Cold vs warm query latency — slice 2b baseline
+# Cold vs warm query latency — initial baseline
 
 - **Date**: 2026-04-11
 - **Harness**: `./scripts/cargo run --release -p firnflow-bench`
@@ -28,6 +28,6 @@ The load-bearing observation: **50 query-kind S3 requests for 50 cold queries, t
 
 ## Notes
 
-- `s3_requests_total` counts firnflow-initiated S3-bound *operations* at the service boundary, not raw HTTP requests to S3 — see the help text on the metric and CLAUDE.md § "Known hard problems" 3 for the approximation caveat.
+- `s3_requests_total` counts firnflow-initiated S3-bound *operations* at the service boundary, not raw HTTP requests to S3 — see the help text on the metric for the approximation caveat.
 - Each run starts cold: the bench uses a fresh `tempfile::tempdir` for the foyer NVMe tier and a fresh namespace timestamp so nothing is reused between runs.
 - The vector dimension here (32) is deliberately smaller than the 1536 used in the serialisation benchmark so the run completes in seconds against MinIO over the `--network host` loopback. Bump it for production-representative numbers.

--- a/bench/results/cold_vs_warm_aws.md
+++ b/bench/results/cold_vs_warm_aws.md
@@ -1,4 +1,4 @@
-# Cold vs warm query latency — realistic parameters (slice 6d)
+# Cold vs warm query latency — realistic parameters
 
 - **Date**: 2026-04-12
 - **Harness**: `./scripts/cargo run --release -p firnflow-bench`

--- a/bench/results/cold_vs_warm_realistic.md
+++ b/bench/results/cold_vs_warm_realistic.md
@@ -1,4 +1,4 @@
-# Cold vs warm query latency — realistic parameters (slice 6d)
+# Cold vs warm query latency — realistic parameters
 
 - **Date**: 2026-04-12
 - **Harness**: `./scripts/cargo run --release -p firnflow-bench`

--- a/bench/results/serialisation.md
+++ b/bench/results/serialisation.md
@@ -1,4 +1,4 @@
-# Serialisation benchmark — spike-3 baseline
+# Serialisation benchmark — initial baseline
 
 - **Date**: 2026-04-11
 - **Benchmark**: `crates/firnflow-core/benches/serialisation.rs`
@@ -27,14 +27,13 @@ decode/1000     6153518    1462.33 µs    1629.96 µs    2855.22 µs    4181.56 
 rt/1000         6153518    2598.19 µs    2765.51 µs    3023.14 µs    7468.15 µs
 ```
 
-## Decision gate (CLAUDE.md § 3)
+## Decision gate
 
 > If bincode round-trip exceeds 1 ms at p99 for 100-result sets,
 > evaluate rkyv and flatbuffers as alternatives.
 
 **100-result round-trip p99 = 317.64 µs ≈ 0.32 ms.** The gate does
-not trigger. See `docs/adr/002-result-serialisation.md` for the
-full decision and alternative analysis.
+not trigger; bincode 2 stays as the cached-result format.
 
 ## Observations
 
@@ -47,10 +46,10 @@ full decision and alternative analysis.
   (bincode's `borrow_decode` or rkyv's zero-copy read) would
   eliminate it.
 - **1000-result tier exceeds 1 ms round-trip** (p99 ≈ 3 ms). This is
-  above the threshold CLAUDE.md set for the 100-result tier but
-  below the threshold for 1000. The spec only gates on 100, so we
-  accept bincode, but the 1000-result number is called out in the
-  ADR as the trigger for a future re-evaluation.
+  above the threshold the project sets for the 100-result tier but
+  below the threshold for 1000. The 100-result tier is the gating
+  decision, so we accept bincode; the 1000-result number is the
+  trigger for a future re-evaluation if real workloads land there.
 - **Encode size is ~6144 bytes per result plus framing.** The raw
   vector is 1536 × 4 = 6144 bytes, so bincode's `config::standard()`
   adds roughly 12 bytes of framing per result — negligible

--- a/crates/firnflow-api/src/auth.rs
+++ b/crates/firnflow-api/src/auth.rs
@@ -21,7 +21,7 @@
 //!   case the single-key fallback promotes the write key to admin
 //!   authority for the duration of the deployment.
 //!
-//! Status codes (concern (4) of `ISSUE_2_CONCERNS.md`):
+//! Status codes:
 //!
 //! | Situation                                   | Status |
 //! | ------------------------------------------- | ------ |
@@ -54,8 +54,8 @@ use crate::error::ApiError;
 const FALLBACK_PEER_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
 /// Reserved label values for `firnflow_auth_rejections_total{reason}`.
-/// Centralised so call sites do not drift away from the cardinality
-/// CLAUDE.md documents.
+/// Centralised so call sites do not drift away from the documented
+/// cardinality.
 pub mod rejection_reason {
     pub const MISSING: &str = "missing";
     pub const INVALID: &str = "invalid";

--- a/crates/firnflow-api/src/error.rs
+++ b/crates/firnflow-api/src/error.rs
@@ -1,11 +1,11 @@
 //! API error type with axum `IntoResponse` integration.
 //!
-//! Promoted from a newtype-over-`FirnflowError` to an enum in 0.5.0
-//! (concern (8) of `ISSUE_2_CONCERNS.md`). API-layer-only conditions
-//! — bearer-token rejection, scope mismatch, rate-limit shedding —
-//! are real variants now rather than synthetic `FirnflowError`s
-//! squeezed through a wrapper. `From<FirnflowError>` is preserved so
-//! handlers continue to use `?` on core calls.
+//! Promoted from a newtype-over-`FirnflowError` to an enum in 0.5.0.
+//! API-layer-only conditions — bearer-token rejection, scope
+//! mismatch, rate-limit shedding — are real variants now rather than
+//! synthetic `FirnflowError`s squeezed through a wrapper.
+//! `From<FirnflowError>` is preserved so handlers continue to use
+//! `?` on core calls.
 
 use std::time::Duration;
 

--- a/crates/firnflow-api/src/handlers.rs
+++ b/crates/firnflow-api/src/handlers.rs
@@ -77,7 +77,7 @@ pub struct UpsertRequest {
 #[derive(Debug, Serialize)]
 pub struct UpsertResponse {
     /// Number of rows accepted for append. Matches `rows.len()` on the
-    /// request — there is no per-row failure reporting in slice 1c.
+    /// request — there is no per-row failure reporting yet.
     pub upserted: usize,
 }
 
@@ -132,8 +132,8 @@ pub async fn delete(
 
 /// Async cache-warmup hint.
 ///
-/// CLAUDE.md: *"the warmup endpoint must be non-blocking: it
-/// spawns an async task and returns 202 immediately"*.
+/// The warmup endpoint is non-blocking: it spawns an async task and
+/// returns 202 immediately.
 ///
 /// The handler validates the namespace, spawns a `tokio::task`
 /// that runs each query from the request body through
@@ -176,7 +176,7 @@ pub struct IndexResponse {
     pub status: String,
 }
 
-/// Explicit ANN index build (slice 6b).
+/// Explicit ANN index build.
 ///
 /// Spawns a background task that builds an IVF_PQ index on the
 /// namespace's vector column and returns `202 Accepted` immediately.
@@ -291,7 +291,7 @@ pub struct CompactResponse {
     pub status: String,
 }
 
-/// Explicit compaction (slice 6c).
+/// Explicit compaction.
 ///
 /// Spawns a background task that merges small data files into
 /// fewer, larger ones and returns `202 Accepted` immediately.

--- a/crates/firnflow-api/tests/api_compact.rs
+++ b/crates/firnflow-api/tests/api_compact.rs
@@ -92,7 +92,7 @@ async fn wait_for_compaction(
 #[ignore]
 async fn compact_reduces_fragments_after_many_upserts() {
     let (app, _tmp, metrics) = build_app_with_metrics().await;
-    let ns = unique_namespace("slice6c");
+    let ns = unique_namespace("compact-test");
     let dim = 8;
 
     // 1. Create fragment explosion: 50 separate upsert calls of

--- a/crates/firnflow-api/tests/api_delete.rs
+++ b/crates/firnflow-api/tests/api_delete.rs
@@ -46,7 +46,7 @@ async fn post_json(app: axum::Router, uri: String, body: Value) -> (StatusCode, 
 #[ignore]
 async fn delete_removes_namespace_and_invalidates_cache() {
     let (app, _tmp) = build_app().await;
-    let ns = unique_namespace("slice3a");
+    let ns = unique_namespace("delete-test");
 
     // 1. Upsert three rows.
     let upsert_body = json!({

--- a/crates/firnflow-api/tests/api_fts.rs
+++ b/crates/firnflow-api/tests/api_fts.rs
@@ -88,7 +88,7 @@ async fn wait_for_index(
 #[ignore]
 async fn vector_fts_and_hybrid_queries() {
     let (app, _tmp, metrics) = build_app_with_metrics().await;
-    let ns = unique_namespace("phase7-fts");
+    let ns = unique_namespace("fts-test");
     // 1. Upsert rows with both vectors and text.
     let upsert_body = json!({
         "rows": [

--- a/crates/firnflow-api/tests/api_index.rs
+++ b/crates/firnflow-api/tests/api_index.rs
@@ -101,7 +101,7 @@ async fn wait_for_index_build(
 #[ignore]
 async fn index_build_returns_202_and_records_metric() {
     let (app, _tmp, metrics) = build_app_with_metrics().await;
-    let ns = unique_namespace("slice6b");
+    let ns = unique_namespace("index-test");
 
     // 1. Upsert 256 rows at dim=32. IVF_PQ needs enough data to
     //    form at least a few partitions — 256 rows is the minimum

--- a/crates/firnflow-api/tests/api_metrics.rs
+++ b/crates/firnflow-api/tests/api_metrics.rs
@@ -90,7 +90,7 @@ fn metric_value(body: &str, metric: &str, label_needle: &str) -> Option<f64> {
 #[ignore]
 async fn metrics_reflect_cache_hits_misses_and_s3_asymmetry() {
     let (app, _tmp) = build_app().await;
-    let ns = unique_namespace("slice2a");
+    let ns = unique_namespace("metrics-test");
 
     // 1. Upsert (records s3_requests{op=upsert} and write_duration)
     let upsert_body = json!({

--- a/crates/firnflow-api/tests/api_scalar_index.rs
+++ b/crates/firnflow-api/tests/api_scalar_index.rs
@@ -115,8 +115,7 @@ fn metric_value(body: &str, metric: &str, label_needle: &str) -> Option<f64> {
 /// `(namespace, kind)` pair reaches `expected`, or the deadline
 /// expires. Returns the last observed count.
 ///
-/// Prometheus emits labels alphabetically (`kind` before `namespace`)
-/// — see CLAUDE.md "Prometheus label ordering is alphabetical."
+/// Prometheus emits labels alphabetically (`kind` before `namespace`).
 async fn wait_for_index_build(
     metrics: &Arc<CoreMetrics>,
     ns: &str,

--- a/crates/firnflow-api/tests/api_smoke.rs
+++ b/crates/firnflow-api/tests/api_smoke.rs
@@ -68,7 +68,7 @@ async fn health_returns_ok() {
 #[ignore]
 async fn upsert_and_query_round_trip() {
     let (app, _tmp) = build_app().await;
-    let ns = unique_namespace("slice1c");
+    let ns = unique_namespace("smoke-test");
 
     // upsert
     let upsert_body = json!({

--- a/crates/firnflow-api/tests/api_warmup.rs
+++ b/crates/firnflow-api/tests/api_warmup.rs
@@ -91,7 +91,7 @@ async fn wait_for_misses(
 #[ignore]
 async fn warmup_returns_202_and_populates_cache() {
     let (app, _tmp, metrics) = build_app_with_metrics().await;
-    let ns = unique_namespace("slice3b");
+    let ns = unique_namespace("warmup-test");
 
     // Upsert some rows so the warmup queries have something to find.
     let upsert_body = json!({

--- a/crates/firnflow-bench/src/main.rs
+++ b/crates/firnflow-bench/src/main.rs
@@ -396,7 +396,7 @@ async fn main() -> anyhow::Result<()> {
     let storage_mb = (cfg.rows as f64 * cfg.dim as f64 * 4.0) / (1024.0 * 1024.0);
 
     let out = format!(
-        "# Cold vs warm query latency — realistic parameters (slice 6d)\n\
+        "# Cold vs warm query latency — realistic parameters\n\
 \n\
 - **Date**: {date}\n\
 - **Harness**: `./scripts/cargo run --release -p firnflow-bench`\n\

--- a/crates/firnflow-core/benches/serialisation.rs
+++ b/crates/firnflow-core/benches/serialisation.rs
@@ -1,19 +1,15 @@
-//! Spike-3 benchmark: serialisation round-trip for cached query
-//! result sets.
+//! Serialisation round-trip benchmark for cached query result sets.
 //!
-//! CLAUDE.md § "Known hard problems" 3:
-//!
-//! > Benchmark serialise + deserialise round-trip time against
-//! > realistic result set sizes: 10 results, 100 results, 1000
-//! > results, each with a 1536-dim vector payload. If bincode
-//! > round-trip exceeds 1 ms at p99 for 100-result sets, evaluate
-//! > rkyv and flatbuffers as alternatives.
+//! Measures encode + decode time at realistic result-set sizes (10,
+//! 100, and 1000 results, each with a 1536-dim vector payload).
+//! Project conventions gate the design choice on the 100-result p99
+//! crossing 1 ms — past that we'd evaluate rkyv and flatbuffers as
+//! alternatives.
 //!
 //! `harness = false` in Cargo.toml means this file is compiled as a
 //! plain binary with its own `main`, which lets us hand-roll exact
 //! p50/p95/p99 measurement — criterion's default stdout doesn't
-//! print p99, and CLAUDE.md gates the design decision on p99
-//! specifically.
+//! print p99, and the design decision is gated on p99 specifically.
 //!
 //! Run with:
 //!

--- a/crates/firnflow-core/src/cache/mod.rs
+++ b/crates/firnflow-core/src/cache/mod.rs
@@ -2,8 +2,11 @@
 //!
 //! A single foyer `HybridCache` (RAM + NVMe) is shared across all
 //! namespaces, with a per-namespace generation counter to make
-//! invalidation on writes O(1). See `docs/adr/001-cache-invalidation.md`
-//! for the rationale behind the generation-counter design.
+//! invalidation on writes O(1). The generation-counter approach
+//! avoids the memory-growth cost of tracking every live cache key
+//! explicitly, has no race window between cache population and key
+//! registration, and is O(1) on write regardless of how many cached
+//! queries exist for a namespace.
 
 mod invalidation;
 mod key;

--- a/crates/firnflow-core/src/lib.rs
+++ b/crates/firnflow-core/src/lib.rs
@@ -1,8 +1,8 @@
 //! firnflow-core — tiered storage primitives for firnflow.
 //!
 //! This crate hosts the foyer-backed cache layer, the namespace
-//! manager, and (in a later spike) the LanceDB wrapper. It is consumed
-//! by `firnflow-api` and `firnflow-bench`.
+//! manager, and the LanceDB wrapper. It is consumed by
+//! `firnflow-api` and `firnflow-bench`.
 
 #![warn(missing_docs)]
 

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -3,7 +3,7 @@
 //! Each namespace maps to its own Lance table rooted at
 //! `s3://{bucket}/{namespace}/`.
 //!
-//! **Per-namespace dimensions (slice 6a):** the manager no longer
+//! **Per-namespace dimensions:** the manager no longer
 //! carries a global `vector_dim`. Instead, dimensions are:
 //!
 //! - **inferred** from the first upsert into a fresh namespace

--- a/crates/firnflow-core/src/metrics.rs
+++ b/crates/firnflow-core/src/metrics.rs
@@ -1,8 +1,8 @@
 //! Prometheus metric handles plumbed through the library layers.
 //!
 //! [`CoreMetrics`] owns a `prometheus::Registry` plus typed counter,
-//! histogram and gauge handles for the exact metric set CLAUDE.md
-//! names:
+//! histogram and gauge handles for the metric set the project
+//! exposes:
 //!
 //! * `firnflow_cache_hits_total{namespace}`
 //! * `firnflow_cache_misses_total{namespace}`

--- a/crates/firnflow-core/src/result.rs
+++ b/crates/firnflow-core/src/result.rs
@@ -3,7 +3,7 @@
 //! These types model what a vector / FTS / hybrid search returns and
 //! are the payload the cache layer serialises and stores as bytes.
 //! The design is deliberately simple so that it exercises a realistic
-//! shape for the spike-3 serialisation benchmark without committing
+//! shape for the serialisation benchmark without committing
 //! prematurely to features (metadata, highlighting, etc.) that will
 //! follow once the API layer is wired up.
 

--- a/crates/firnflow-core/src/service.rs
+++ b/crates/firnflow-core/src/service.rs
@@ -1,22 +1,17 @@
-//! Namespace service — the layer where the three spike results
-//! finally meet.
+//! Namespace service — combines the Lance backend, the foyer hybrid
+//! cache, and the bincode result-payload format into a single
+//! cache-aside read path with invalidate-on-write.
 //!
-//! Combines:
-//!
-//! * [`NamespaceManager`] — the Lance backend (spike-2)
+//! * [`NamespaceManager`] — the Lance backend
 //! * [`NamespaceCache`] — foyer hybrid cache + generation counter
-//!   (spike-1)
 //! * bincode-2 serde path — the cached result payload format
-//!   (spike-3, ADR-002)
 //!
-//! into a single cache-aside read path with invalidate-on-write.
-//! The axum handlers in slice 1c own an `Arc<NamespaceService>`
-//! and call straight into `upsert` / `query`.
+//! The axum handlers own an `Arc<NamespaceService>` and call
+//! straight into `upsert` / `query`.
 //!
-//! Instrumentation (slice 2a): every call records query/write
-//! duration histograms and an `s3_requests_total` counter. The
-//! cache hit/miss counters live on the cache itself — see
-//! [`NamespaceCache::get_or_populate`].
+//! Every call records query/write duration histograms and an
+//! `s3_requests_total` counter. The cache hit/miss counters live on
+//! the cache itself — see [`NamespaceCache::get_or_populate`].
 
 use std::sync::Arc;
 use std::time::Instant;

--- a/crates/firnflow-core/tests/lance_concurrent_writes.rs
+++ b/crates/firnflow-core/tests/lance_concurrent_writes.rs
@@ -1,9 +1,8 @@
-//! Spike-2b: LanceDB concurrent-writer stress test.
+//! LanceDB concurrent-writer stress test.
 //!
-//! CLAUDE.md § "Known hard problems" 2:
-//! > N writers to the same namespace simultaneously, each appending
-//! > M rows. After all writes complete, query the full table and
-//! > assert row count == N * M.
+//! N writers to the same namespace simultaneously, each appending
+//! M rows. After all writes complete, query the full table and
+//! assert row count == N * M.
 //!
 //! Gated `#[ignore]`: the test talks to MinIO or real AWS S3, both of
 //! which are out-of-process. Run with:
@@ -176,7 +175,7 @@ async fn connect(uri: &str, opts: &HashMap<String, String>) -> lancedb::Connecti
 }
 
 async fn run_stress(uri_base: String, opts: HashMap<String, String>) {
-    let ns = unique_namespace("spike2b");
+    let ns = unique_namespace("concurrent-writers");
     let uri = format!("{uri_base}/{ns}");
     let schema = schema();
 
@@ -237,7 +236,7 @@ async fn concurrent_writers_preserve_all_rows_minio() {
 #[ignore]
 async fn concurrent_writers_preserve_all_rows_aws() {
     if std::env::var("AWS_PROFILE").is_err() {
-        eprintln!("SKIP: AWS_PROFILE not set; real-AWS spike-2b needs a configured CLI profile");
+        eprintln!("SKIP: AWS_PROFILE not set; real-AWS run needs a configured CLI profile");
         return;
     }
     let bucket = env_or("FIRNFLOW_AWS_BUCKET", "firnflow-cloudfloe");
@@ -245,8 +244,8 @@ async fn concurrent_writers_preserve_all_rows_aws() {
     run_stress(uri_base, aws_storage_options()).await;
 }
 
-/// CLAUDE.md § "Known hard problems" 2 demands 100 passing runs as
-/// the definition of done for this spike. Each iteration uses a fresh
+/// 100 passing runs are the project's definition of done for the
+/// concurrent-writer stress test. Each iteration uses a fresh
 /// namespace; total S3 footprint is bounded by (iterations × 800 rows).
 #[tokio::test]
 #[ignore]
@@ -267,7 +266,7 @@ async fn concurrent_writers_100_runs_minio() {
 #[ignore]
 async fn concurrent_writers_100_runs_aws() {
     if std::env::var("AWS_PROFILE").is_err() {
-        eprintln!("SKIP: AWS_PROFILE not set; real-AWS spike-2b needs a configured CLI profile");
+        eprintln!("SKIP: AWS_PROFILE not set; real-AWS run needs a configured CLI profile");
         return;
     }
     const RUNS: usize = 100;

--- a/crates/firnflow-core/tests/manager_per_namespace_dim.rs
+++ b/crates/firnflow-core/tests/manager_per_namespace_dim.rs
@@ -64,9 +64,9 @@ async fn three_namespaces_with_different_dims() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
 
-    let ns4 = NamespaceId::new(unique_namespace("slice6a-dim4")).unwrap();
-    let ns8 = NamespaceId::new(unique_namespace("slice6a-dim8")).unwrap();
-    let ns16 = NamespaceId::new(unique_namespace("slice6a-dim16")).unwrap();
+    let ns4 = NamespaceId::new(unique_namespace("multi-dim-4")).unwrap();
+    let ns8 = NamespaceId::new(unique_namespace("multi-dim-8")).unwrap();
+    let ns16 = NamespaceId::new(unique_namespace("multi-dim-16")).unwrap();
 
     // ---- upsert into each namespace with its own dimension ----
     manager
@@ -173,7 +173,7 @@ async fn three_namespaces_with_different_dims() {
 async fn first_upsert_infers_dim_and_validates_remaining_rows() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
-    let ns = NamespaceId::new(unique_namespace("slice6a-infer")).unwrap();
+    let ns = NamespaceId::new(unique_namespace("dim-inference")).unwrap();
 
     // Row 0 has dim=4, row 1 has dim=6 — must fail with a clear error.
     let err = manager

--- a/crates/firnflow-core/tests/manager_upsert_query.rs
+++ b/crates/firnflow-core/tests/manager_upsert_query.rs
@@ -64,7 +64,7 @@ fn unit_vector(axis: usize) -> Vec<f32> {
 async fn upsert_then_query_returns_nearest_neighbor() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
-    let ns = NamespaceId::new(unique_namespace("slice1a")).unwrap();
+    let ns = NamespaceId::new(unique_namespace("upsert-query")).unwrap();
 
     // Four orthogonal unit vectors along the first four axes.
     let rows: Vec<UpsertRow> = vec![
@@ -106,7 +106,7 @@ async fn upsert_then_query_returns_nearest_neighbor() {
 async fn upsert_validates_vector_dimension() {
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let manager = NamespaceManager::new(bucket, minio_options(), test_metrics());
-    let ns = NamespaceId::new(unique_namespace("slice1a-dim")).unwrap();
+    let ns = NamespaceId::new(unique_namespace("dim-validation")).unwrap();
 
     // Establish the namespace dimension via a valid first upsert.
     let rows: Vec<UpsertRow> = vec![(1u64, unit_vector(0)).into()];

--- a/crates/firnflow-core/tests/s3_conditional_writes.rs
+++ b/crates/firnflow-core/tests/s3_conditional_writes.rs
@@ -1,8 +1,8 @@
-//! Spike-2 pre-flight.
+//! Conditional-write pre-flight.
 //!
 //! Verifies that the S3 backend honours `If-None-Match: *` on
 //! PutObject before we trust Lance's CAS-based WAL on top of it.
-//! CLAUDE.md mandates this check: a backend that silently ignores the
+//! This check is required: a backend that silently ignores the
 //! precondition will pass Lance's row-count assertion at low contention
 //! and fail in production.
 //!
@@ -56,7 +56,7 @@ async fn minio_client() -> Client {
 }
 
 /// Real-AWS client: default credential chain (respects `AWS_PROFILE`),
-/// region from `AWS_REGION` or falling back to eu-west-1 per CLAUDE.md.
+/// region from `AWS_REGION` or falling back to eu-west-1.
 async fn aws_client() -> Client {
     let region = env_or("AWS_REGION", "eu-west-1");
     let shared = aws_config::defaults(BehaviorVersion::latest())
@@ -141,7 +141,7 @@ async fn ensure_bucket(client: &Client, bucket: &str) {
 /// The shared assertion: two PUTs with `If-None-Match: *` to the same
 /// key. First must succeed, second must fail with HTTP 412.
 async fn assert_if_none_match_rejects_second_put(client: &Client, bucket: &str) {
-    let key = unique_key("spike2/cond-write");
+    let key = unique_key("preflight/cond-write");
 
     client
         .put_object()
@@ -171,7 +171,7 @@ async fn assert_if_none_match_rejects_second_put(client: &Client, bucket: &str) 
         status, 412,
         "backend must return 412 Precondition Failed on the second If-None-Match=* PUT; \
          got {status}. A backend that silently ignores the precondition will pass at low \
-         contention and fail Lance's CAS-based WAL under load, so do not proceed to spike-2b."
+         contention and fail Lance's CAS-based WAL under load, so do not proceed to the concurrent-writer stress."
     );
 
     // Best-effort cleanup; leaked keys are harmless for a throwaway bucket.

--- a/crates/firnflow-core/tests/service_cache_aside.rs
+++ b/crates/firnflow-core/tests/service_cache_aside.rs
@@ -1,6 +1,6 @@
-//! Slice-1b integration test: `NamespaceService` cache-aside cycle.
+//! `NamespaceService` cache-aside cycle integration test.
 //!
-//! Proves the full loop where the three spike results meet:
+//! Proves the full loop:
 //!
 //! 1. upsert via the service → rows land in Lance, cache is invalidated
 //! 2. query via the service → cache miss, manager runs the search,
@@ -99,7 +99,7 @@ async fn service_cache_aside_invalidates_on_upsert() {
         Arc::clone(&metrics),
     );
 
-    let ns = NamespaceId::new(unique_namespace("slice1b")).unwrap();
+    let ns = NamespaceId::new(unique_namespace("cache-aside")).unwrap();
     let req = QueryRequest {
         vector: unit_vector(0),
         k: 10,

--- a/scripts/cargo
+++ b/scripts/cargo
@@ -18,9 +18,9 @@ fi
 mkdir -p "${PROJECT_ROOT}/.cargo-cache"
 
 # Mount the host's ~/.aws read-only when AWS_PROFILE is set so that
-# spike-2 tests can reach real AWS S3 via the host's configured
-# credentials. Path redirected to /aws so we don't conflict with
-# the container's HOME layout.
+# the AWS-backed conditional-write tests can reach real AWS S3 via
+# the host's configured credentials. Path redirected to /aws so we
+# don't conflict with the container's HOME layout.
 AWS_MOUNT_ARGS=()
 if [ -n "${AWS_PROFILE:-}" ] && [ -d "${HOME}/.aws" ]; then
     AWS_MOUNT_ARGS+=(


### PR DESCRIPTION
## Summary

Removes citations to local-only or old non-existent files from the tracked source tree, plus internal session-tracking shorthand that was leaking into module rustdoc, comments, and test namespace strings.