### PR TITLE
Add v0.6.0 native-GCS callout to the homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,6 +63,9 @@
       The result: your data lives cheaply on object storage, but hot queries feel local. The <code>/metrics</code> endpoint shows exactly how many backend requests the cache is saving you.
     </p>
     <p>
+      New in 0.6.0: native Google Cloud Storage support. Set <code>FIRNFLOW_STORAGE_URI=gs://your-bucket</code> and Firn routes through lancedb's native GCS backend, using the GCS XML API's generation precondition (<code>x-goog-if-generation-match: 0</code>) instead of <code>If-None-Match: *</code>. Validated by the same 100-run Lance concurrent-writer stress that gates every other backend. Switching between AWS S3, MinIO, Cloudflare R2, Tigris, DigitalOcean Spaces, and native GCS is a single env-var change &mdash; see the <a href="https://github.com/gordonmurray/firnflow#backend-configuration">backend configuration recipes</a>.
+    </p>
+    <p>
       Production hardening, new in 0.5.0: optional bearer-token authentication with a read/write and admin scope split, optional <code>tower-governor</code> rate limiting keyed on the validated principal, and an opt-in <code>/metrics</code> token. See <a href="configuration.html#authentication">configuration</a> and <a href="deployment.html#authentication-and-rate-limiting">deployment</a>.
     </p>
 


### PR DESCRIPTION
## Summary

The homepage how-it-works section on firnflow.io already includes a "new in 0.5.0" paragraph for the bearer-token authentication and rate-limiting work. After v0.6.0 was tagged, the homepage still read as if 0.5.0 was the latest release — no mention of native GCS support anywhere above the documentation cards.

Adds a parallel paragraph leading with the v0.6.0 work: native Google Cloud Storage routing, the generation precondition that replaces `If-None-Match: *` on the GCS XML API, the env-var-only backend switch, and a deep link to the README's Backend Configuration recipes. The existing 0.5.0 paragraph stays underneath as the secondary historical callout.

Copy-only change; no Rust, no metric or config-name impact.

## Tests

Static HTML; visual inspection only. No site-build pipeline touches this branch.