### PR TITLE
Document semantic cache usage

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -357,7 +357,7 @@
         <span class="endpoint-desc">Pre-warm the cache (async)</span>
       </div>
       <div class="endpoint-body">
-        <p>Accepts a list of queries and runs them in a background task to populate the cache. Returns <code>202 Accepted</code> immediately. Useful for warming the cache after a deployment or before expected traffic.</p>
+        <p>Accepts a list of queries and runs them in a background task to populate the cache. Returns <code>202 Accepted</code> immediately. Useful for warming the cache after a deployment or before expected traffic. Query objects use the same schema as <code>/query</code>; include <code>semantic_cache: {"enabled": true}</code> on eligible single-vector warmup queries if you also want to seed the semantic sidecar.</p>
 
         <h4>Request body</h4>
         <table>
@@ -388,7 +388,7 @@
 
         <div class="callout callout-info">
           <div class="callout-title">Monitoring warmup progress</div>
-          Watch the <code>firnflow_cache_misses_total</code> metric to track how many warmup queries have completed. Failures inside the background task are logged server-side but do not affect the HTTP response.
+          Watch the <code>firnflow_cache_misses_total</code> metric to track how many warmup queries have completed. For semantic warmup, also watch <code>firnflow_semantic_cache_rejections_total{reason="empty_index"}</code> at startup and <code>firnflow_semantic_cache_hits_total</code> once near-duplicate traffic starts. Failures inside the background task are logged server-side but do not affect the HTTP response.
         </div>
       </div>
     </div>

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -60,7 +60,8 @@
       </tbody>
     </table>
 
-    <p>The cache stores complete, serialised query result sets. When a query hits the cache, zero bytes are read from object storage. When it misses, the result is fetched from the backend and stored in the cache for future use.</p>
+    <p>The exact cache stores complete, serialised query result sets. When a query hits the cache, zero bytes are read from object storage. When it misses, the result is fetched from the backend and stored in the cache for future use.</p>
+    <p>Single-vector queries can also opt into a small in-memory semantic sidecar. After an exact-cache miss, Firn can compare the incoming query vector with recent cached query vectors in the same namespace generation. If cosine similarity clears the request's threshold and <code>k</code> / <code>nprobes</code> match, Firn reuses the previous top-k bytes without touching object storage. This is approximate result reuse, so callers must opt in per request.</p>
 
     <h2>Request middleware</h2>
     <p>Every protected endpoint runs through a fixed middleware stack before the handler. The stack is wired up in <code>firnflow_api::router</code> and the order is load-bearing — bucketing on a validated <code>Principal</code> rather than an attacker-supplied header is the whole reason auth runs first.</p>
@@ -87,12 +88,14 @@ handler</code></pre>
     <h2>Query path</h2>
     <p>Every query follows this exact sequence:</p>
     <ol>
-      <li><strong>Hash the query.</strong> The full <code>QueryRequest</code> (vector, k, nprobes, text) is serialised with bincode and hashed with xxh3 to produce a deterministic <code>QueryHash</code>.</li>
+      <li><strong>Hash the query.</strong> The cacheable search fields in <code>QueryRequest</code> (vector, vectors, k, nprobes, text) are serialised with bincode and hashed with xxh3 to produce a deterministic <code>QueryHash</code>. The <code>semantic_cache</code> control block is deliberately excluded so toggling it does not split otherwise-identical exact-cache entries.</li>
       <li><strong>Build the cache key.</strong> The key is a tuple of <code>(namespace, generation, query_hash)</code>. The generation counter ensures stale results are never returned after a write.</li>
       <li><strong>Check foyer.</strong> The HybridCache checks RAM first, then NVMe. On a hit, the serialised result is returned and a <code>cache_hits_total</code> metric is recorded.</li>
-      <li><strong>On miss: query object storage.</strong> LanceDB runs the query against the Lance table on the configured backend (vector nearest-neighbour, BM25 FTS, or hybrid) using the namespace's pooled <code>Connection</code> and <code>Table</code> handle &mdash; the first request for a namespace opens and caches the handle, every subsequent request skips the credential-resolution and manifest-read round-trips. The result is serialised with bincode and stored in foyer. A <code>cache_misses_total</code> and <code>s3_requests_total</code> metric are recorded. (The metric name predates native GCS support; it now counts object-store operations regardless of backend.)</li>
+      <li><strong>Optional semantic lookup.</strong> If the exact cache misses and the request includes <code>semantic_cache.enabled: true</code>, Firn scans the namespace's in-memory semantic sidecar for a nearby single-vector query with matching <code>k</code> and resolved <code>nprobes</code>. A hit returns that cached result immediately and records <code>firnflow_semantic_cache_hits_total</code>. Ineligible shapes such as multivector, FTS, and hybrid requests return 400 when semantic caching is enabled.</li>
+      <li><strong>On miss: query object storage.</strong> LanceDB runs the query against the Lance table on the configured backend (vector nearest-neighbour, multivector, BM25 FTS, or hybrid) using the namespace's pooled <code>Connection</code> and <code>Table</code> handle &mdash; the first request for a namespace opens and caches the handle, every subsequent request skips the credential-resolution and manifest-read round-trips. The result is serialised with bincode and stored in foyer. Eligible semantic-cache requests also add the query vector and result bytes to the sidecar. The exact-cache miss counter was already recorded before the semantic lookup; backend work records <code>s3_requests_total</code>. (The metric name predates native GCS support; it now counts object-store operations regardless of backend.)</li>
       <li><strong>Return the result.</strong> The query duration (cache hit or miss) is recorded in the <code>query_duration_seconds</code> histogram.</li>
     </ol>
+    <p>The semantic sidecar is bounded to 1024 entries per namespace generation and lives only in the Firn process. Writes, deletes, and compactions drop it alongside the exact cache; index builds leave both layers intact because rows have not changed.</p>
 
     <h2>Write path</h2>
     <p>Writes follow a strict ordering to prevent stale cache state:</p>

--- a/docs/deployment.html
+++ b/docs/deployment.html
@@ -226,7 +226,7 @@ readinessProbe:
       {"vector": [0.0, 1.0, ...], "k": 10}
     ]
   }'</code></pre>
-    <p>This returns immediately (202) and runs the queries in the background, populating the cache as it goes. Monitor <code>firnflow_cache_misses_total</code> to track warmup progress.</p>
+    <p>This returns immediately (202) and runs the queries in the background, populating the exact cache as it goes. If your production traffic uses semantic caching, include the same <code>semantic_cache</code> block on eligible single-vector warmup queries so the in-memory semantic sidecar is seeded too. Monitor <code>firnflow_cache_misses_total</code> to track warmup progress and <code>firnflow_semantic_cache_hits_total</code> / <code>firnflow_semantic_cache_rejections_total</code> to confirm the semantic layer is behaving as expected.</p>
 
     <h2>Recommended operational setup</h2>
     <ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,10 +57,10 @@
 
     <h2>How it works</h2>
     <p>
-      Firn stores every namespace under its own object-storage prefix using <strong>LanceDB</strong> as the storage engine. A tiered cache powered by <strong>foyer</strong> sits in front of the backend, serving repeated queries from RAM or NVMe in microseconds instead of milliseconds. Writes automatically invalidate the cache for the affected namespace using an O(1) generation counter strategy.
+      Firn stores every namespace under its own object-storage prefix using <strong>LanceDB</strong> as the storage engine. A tiered cache powered by <strong>foyer</strong> sits in front of the backend, serving repeated queries from RAM or NVMe in microseconds instead of milliseconds. Single-vector queries can also opt into semantic caching, where a near-duplicate query may reuse a previous top-k result when its vector clears your cosine-similarity threshold. Writes automatically invalidate both cache layers for the affected namespace using an O(1) generation counter strategy.
     </p>
     <p>
-      The result: your data lives cheaply on object storage, but hot queries feel local. The <code>/metrics</code> endpoint shows exactly how many backend requests the cache is saving you.
+      The result: your data lives cheaply on object storage, but hot and near-duplicate queries can feel local. The <code>/metrics</code> endpoint shows exactly how many backend requests the exact and semantic cache layers are saving you.
     </p>
     <p>
       New in 0.6.0: native Google Cloud Storage support. Set <code>FIRNFLOW_STORAGE_URI=gs://your-bucket</code> and Firn routes through lancedb's native GCS backend, using the GCS XML API's generation precondition (<code>x-goog-if-generation-match: 0</code>) instead of <code>If-None-Match: *</code>. Validated by the same 100-run Lance concurrent-writer stress that gates every other backend. Switching between AWS S3, MinIO, Cloudflare R2, Tigris, DigitalOcean Spaces, and native GCS is a single env-var change &mdash; see the <a href="https://github.com/gordonmurray/firnflow#backend-configuration">backend configuration recipes</a>.

--- a/docs/monitoring.html
+++ b/docs/monitoring.html
@@ -82,7 +82,25 @@ scrape_configs:
           <td><code>firnflow_cache_misses_total</code></td>
           <td>Counter</td>
           <td><code>namespace</code></td>
-          <td>Total cache misses. Each miss triggered a query to the configured backend via LanceDB and populated the cache.</td>
+          <td>Total exact-cache misses. Without semantic caching, each miss reaches the configured backend via LanceDB. With <code>semantic_cache.enabled: true</code>, a semantic-cache hit can still avoid the backend after this counter increments.</td>
+        </tr>
+        <tr>
+          <td><code>firnflow_semantic_cache_hits_total</code></td>
+          <td>Counter</td>
+          <td><code>namespace</code></td>
+          <td>Opt-in semantic-cache hits. Each hit reused a previous near-duplicate single-vector query's top-k result after the exact cache missed.</td>
+        </tr>
+        <tr>
+          <td><code>firnflow_semantic_cache_misses_total</code></td>
+          <td>Counter</td>
+          <td><code>namespace</code></td>
+          <td>Eligible semantic-cache lookups where the sidecar had entries, but no cached query cleared the request's <code>min_similarity</code> threshold with matching <code>k</code> and <code>nprobes</code>.</td>
+        </tr>
+        <tr>
+          <td><code>firnflow_semantic_cache_rejections_total</code></td>
+          <td>Counter</td>
+          <td><code>namespace</code>, <code>reason</code></td>
+          <td>Semantic-cache lookups rejected before a similarity scan. Reasons are bounded to <code>unsupported_query_shape</code> and <code>empty_index</code>.</td>
         </tr>
       </tbody>
     </table>
@@ -95,7 +113,7 @@ scrape_configs:
           <td><code>firnflow_query_duration_seconds</code></td>
           <td>Histogram</td>
           <td><code>namespace</code>, <code>query_type</code></td>
-          <td>End-to-end query latency through the cache-aside path, including serialisation. The <code>query_type</code> label is <code>vector</code>, <code>fts</code>, or <code>hybrid</code>.</td>
+          <td>End-to-end query latency through the cache-aside path, including serialisation. The <code>query_type</code> label is <code>vector</code>, <code>multivector</code>, <code>fts</code>, or <code>hybrid</code>.</td>
         </tr>
         <tr>
           <td><code>firnflow_write_duration_seconds</code></td>
@@ -126,7 +144,7 @@ scrape_configs:
           <td><code>firnflow_s3_requests_total</code></td>
           <td>Counter</td>
           <td><code>namespace</code>, <code>operation</code></td>
-          <td>Number of Firn-initiated operations that hit the configured object-storage backend. Operations: <code>query</code> (cache miss), <code>upsert</code>, <code>delete</code>. This is the primary signal for whether the cache is saving you backend request costs. The metric name predates native GCS support and counts requests against any backend (S3-family or native GCS); it is kept as <code>s3_requests_total</code> for dashboard continuity.</td>
+          <td>Number of Firn-initiated operations that hit the configured object-storage backend. Operations include <code>query</code>, <code>upsert</code>, and <code>delete</code>. This is the primary signal for whether the cache is saving you backend request costs. The metric name predates native GCS support and counts requests against any backend (S3-family or native GCS); it is kept as <code>s3_requests_total</code> for dashboard continuity.</td>
         </tr>
         <tr>
           <td><code>firnflow_active_namespaces</code></td>
@@ -145,7 +163,7 @@ scrape_configs:
 
     <div class="callout callout-info">
       <div class="callout-title">The key metric</div>
-      <code>firnflow_s3_requests_total</code> is the metric that proves the cache is working. Compare <code>s3_requests_total{operation="query"}</code> against <code>cache_misses_total</code>; they should be equal. The difference between total queries and cache misses is how many object-storage requests the cache has eliminated. (The metric name is historical and kept stable for dashboard continuity; it counts requests against any configured backend.)
+      <code>firnflow_s3_requests_total</code> is the metric that proves backend work happened. For exact-cache-only traffic, compare <code>s3_requests_total{operation="query"}</code> against <code>cache_misses_total</code>; they should be equal. For semantic-cache traffic, semantic hits make <code>s3_requests_total{operation="query"}</code> lower than exact-cache misses. (The metric name is historical and kept stable for dashboard continuity; it counts requests against any configured backend.)
     </div>
 
     <h3>Auth and rate-limit metrics</h3>
@@ -194,8 +212,16 @@ histogram_quantile(0.99, rate(firnflow_query_duration_seconds_bucket[5m]))</code
     <pre><code>rate(firnflow_s3_requests_total{namespace="production"}[5m])</code></pre>
 
     <h3>Object-storage requests saved (total avoided queries)</h3>
-    <pre><code>sum(firnflow_cache_hits_total)</code></pre>
-    <p>Each cache hit is one object-storage request that did not happen.</p>
+    <pre><code>sum(firnflow_cache_hits_total) + sum(firnflow_semantic_cache_hits_total)</code></pre>
+    <p>Each exact-cache hit and semantic-cache hit is one object-storage query that did not happen. Semantic-cache hits are approximate result reuse, so track them separately when correctness calibration matters.</p>
+
+    <h3>Semantic-cache hit rate (eligible lookups)</h3>
+    <pre><code>sum(rate(firnflow_semantic_cache_hits_total[5m]))
+/
+(sum(rate(firnflow_semantic_cache_hits_total[5m])) + sum(rate(firnflow_semantic_cache_misses_total[5m])))</code></pre>
+
+    <h3>Semantic-cache rejections by reason</h3>
+    <pre><code>sum by (reason) (rate(firnflow_semantic_cache_rejections_total[5m]))</code></pre>
 
     <h3>Write throughput</h3>
     <pre><code>rate(firnflow_s3_requests_total{operation="upsert"}[5m])</code></pre>
@@ -317,6 +343,7 @@ groups:
     <ul>
       <li>Cache hit rate above 80% for read-heavy workloads</li>
       <li><code>s3_requests_total{operation=query}</code> rate is low and stable</li>
+      <li>Semantic-cache hit rate is stable for workloads that opt into <code>semantic_cache</code>, with rejections mostly from <code>empty_index</code> immediately after startup or writes</li>
       <li>Query latency p99 under 10ms (warm queries dominate)</li>
     </ul>
 
@@ -324,6 +351,7 @@ groups:
     <ul>
       <li><strong>Falling cache hit rate:</strong> the working set may exceed cache capacity. Increase <code>FIRNFLOW_CACHE_MEMORY_BYTES</code> or <code>FIRNFLOW_CACHE_NVME_BYTES</code>.</li>
       <li><strong>High <code>s3_requests_total</code> rate:</strong> too many cache misses are reaching the object-storage backend. This costs money and adds latency. Consider cache warmup, larger cache, or building an index.</li>
+      <li><strong>Low semantic-cache hit rate:</strong> the threshold may be too strict for your embedding model, or query vectors may not cluster tightly enough for safe reuse. Lower <code>semantic_cache.min_similarity</code> only after measuring result quality on your corpus.</li>
       <li><strong>Rising query latency:</strong> if cold queries dominate, build an IVF_PQ index. If warm queries are slow, check for serialisation overhead with large result sets.</li>
       <li><strong>Write duration spikes:</strong> may indicate backend throttling or contention. Check the object-storage request metrics and consider compaction.</li>
     </ul>

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -104,7 +104,32 @@ docker compose up --build</code></pre>
       Run the same query again. The second call returns from cache with zero object-storage requests. You can verify this at <code>/metrics</code>.
     </div>
 
-    <h2>5. Add text for full-text search</h2>
+    <h2>5. Try semantic caching</h2>
+    <p>The exact cache only helps when the same query repeats. For single-vector workloads, you can opt into semantic caching so a near-duplicate query can reuse a previous top-k result when cosine similarity clears your threshold.</p>
+    <pre><code># First query: populates the exact cache and the semantic sidecar.
+curl -X POST http://localhost:3000/ns/demo/query \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "vector": [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    "k": 2,
+    "semantic_cache": {"enabled": true, "min_similarity": 0.98}
+  }'
+
+# Near-duplicate query: exact cache misses, semantic cache may hit.
+curl -X POST http://localhost:3000/ns/demo/query \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "vector": [0.0, 0.999, 0.001, 0.0, 0.0, 0.0, 0.0, 0.0],
+    "k": 2,
+    "semantic_cache": {"enabled": true, "min_similarity": 0.98}
+  }'</code></pre>
+
+    <div class="callout callout-warning">
+      <div class="callout-title">Approximate reuse</div>
+      A semantic-cache hit reuses an earlier result; it does not run a fresh search for the new vector. Start with the default threshold (<code>0.995</code>) and lower <code>min_similarity</code> only after measuring result quality for your model and corpus. V1 supports single-vector queries only, with no <code>text</code> or <code>vectors</code> field.
+    </div>
+
+    <h2>6. Add text for full-text search</h2>
     <p>Upsert rows with both vectors and text, then build an FTS index.</p>
     <pre><code># Upsert with text
 curl -X POST http://localhost:3000/ns/articles/upsert \
@@ -134,16 +159,17 @@ curl -X POST http://localhost:3000/ns/articles/fts-index</code></pre>
     "k": 2
   }'</code></pre>
 
-    <h2>6. Check the metrics</h2>
+    <h2>7. Check the metrics</h2>
     <p>See exactly how many object-storage requests Firn has saved you.</p>
     <pre><code>curl -s http://localhost:3000/metrics | grep firnflow</code></pre>
-    <p>Key lines to look for:</p>
-    <pre><code>firnflow_cache_hits_total{namespace="demo"} 1
-firnflow_cache_misses_total{namespace="demo"} 1
-firnflow_s3_requests_total{namespace="demo",operation="query"} 1
-firnflow_active_namespaces 1
-firnflow_cached_handles 1</code></pre>
-    <p>The cache miss count stays at 1 no matter how many times you repeat the same query. Every subsequent hit is free. <code>firnflow_cached_handles</code> tracks namespaces with a warm LanceDB connection in the in-process pool &mdash; the first request to any namespace opens the connection, every later request reuses it.</p>
+    <p>Key metric families to look for:</p>
+    <pre><code>firnflow_cache_hits_total{namespace="demo"} ...
+firnflow_cache_misses_total{namespace="demo"} ...
+firnflow_semantic_cache_hits_total{namespace="demo"} ...
+firnflow_s3_requests_total{namespace="demo",operation="query"} ...
+firnflow_active_namespaces ...
+firnflow_cached_handles ...</code></pre>
+    <p>The exact cache miss count increments when a query misses the RAM/NVMe result cache. If semantic caching hits after that, <code>firnflow_semantic_cache_hits_total</code> increments and <code>firnflow_s3_requests_total{operation="query"}</code> does not. <code>firnflow_cached_handles</code> tracks namespaces with a warm LanceDB connection in the in-process pool &mdash; the first request to any namespace opens the connection, every later request reuses it.</p>
 
     <h2>Next steps</h2>
     <ul>


### PR DESCRIPTION
## Summary

Update the public docs for the new opt-in semantic cache behavior across the API reference, quickstart, architecture, deployment, homepage, and monitoring guide.

## Behavior notes

- Clarifies that semantic caching is single-vector-only in v1 and is approximate result reuse, not a fresh backend search.
- Documents the semantic-cache metrics and the changed relationship between exact-cache misses and object-storage query requests when semantic hits occur.
- Adds warmup guidance for seeding the in-memory semantic sidecar.

## Tests

~~~text
git diff --check -- docs
~~~