### PR TITLE
Fix stale cache reads after a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `NamespaceCache::close()` flushes the foyer NVMe write buffer and shuts the cache down cleanly, so entries inserted before the call are durable on disk. Groundwork for graceful shutdown (#13).
-- `NamespaceManager::generation()` returns a namespace's current Lance table version, and `NamespaceCache::set_generation()` seeds the shared generation counter from it. The query read path now derives the cache key's generation from this persistent version rather than a process-local counter (see Fixed).
+- `NamespaceManager::generation()` returns a namespace's cache generation, derived from its Lance table version and the manifest commit timestamp, and `NamespaceCache::set_generation()` seeds the shared generation counter from it. The query read path now derives the cache key's generation from this persistent value rather than a process-local counter (see Fixed).
 
 ### Changed
 - Building an index (IVF_PQ, FTS, or scalar BTree) now invalidates a namespace's cached query results. An index build is a Lance commit that advances the table version, which is the cache generation, so post-build queries re-run against the new index instead of replaying a pre-index cached result. Previously index builds left the cache untouched. Index builds are infrequent and operator-triggered, so dropping the warm cache afterwards is a minor cost for the safer behaviour.
 
 ### Fixed
-- The result cache could serve stale results after a process restart. The per-namespace generation counter that keys cached entries lived only in memory and reset to 0 on restart, while the foyer NVMe tier persists and recovers its entries on reopen — so a repeat query at a replayed generation could be served a result from before a write that had already bumped the generation. The generation is now derived from the Lance table version, a persistent value that advances on every commit, so a recovered NVMe entry is reachable only when the namespace has not changed since the entry was stored. Reproduced by `crates/firnflow-core/tests/cache_restart_staleness.rs`.
+- The result cache could serve stale results after a process restart. The per-namespace generation counter that keys cached entries lived only in memory and reset to 0 on restart, while the foyer NVMe tier persists and recovers its entries on reopen — so a repeat query at a replayed generation could be served a result from before a write that had already bumped the generation. The generation is now derived from the Lance table version, a persistent value that advances on every commit, so a recovered NVMe entry is reachable only when the namespace has not changed since the entry was stored. The generation also folds in the manifest commit timestamp, so deleting a namespace and recreating it under the same name cannot serve the deleted incarnation's cached results even when the new incarnation reaches the same Lance version. Reproduced by `crates/firnflow-core/tests/cache_restart_staleness.rs` and `tests/service_cache_aside.rs::delete_recreate_does_not_serve_old_incarnation`.
 
 ## [0.8.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `NamespaceCache::close()` flushes the foyer NVMe write buffer and shuts the cache down cleanly, so entries inserted before the call are durable on disk. Groundwork for graceful shutdown (#13).
+- `NamespaceManager::generation()` returns a namespace's current Lance table version, and `NamespaceCache::set_generation()` seeds the shared generation counter from it. The query read path now derives the cache key's generation from this persistent version rather than a process-local counter (see Fixed).
+
+### Changed
+- Building an index (IVF_PQ, FTS, or scalar BTree) now invalidates a namespace's cached query results. An index build is a Lance commit that advances the table version, which is the cache generation, so post-build queries re-run against the new index instead of replaying a pre-index cached result. Previously index builds left the cache untouched. Index builds are infrequent and operator-triggered, so dropping the warm cache afterwards is a minor cost for the safer behaviour.
+
+### Fixed
+- The result cache could serve stale results after a process restart. The per-namespace generation counter that keys cached entries lived only in memory and reset to 0 on restart, while the foyer NVMe tier persists and recovers its entries on reopen — so a repeat query at a replayed generation could be served a result from before a write that had already bumped the generation. The generation is now derived from the Lance table version, a persistent value that advances on every commit, so a recovered NVMe entry is reachable only when the namespace has not changed since the entry was stored. Reproduced by `crates/firnflow-core/tests/cache_restart_staleness.rs`.
+
 ## [0.8.0] - 2026-05-31
 
 ### Added

--- a/crates/firnflow-core/src/cache/invalidation.rs
+++ b/crates/firnflow-core/src/cache/invalidation.rs
@@ -41,6 +41,24 @@ impl GenerationCounter {
         let entry = self.inner.entry(ns.clone()).or_default();
         entry.fetch_add(1, Ordering::AcqRel) + 1
     }
+
+    /// Overwrite the generation for a namespace with an externally
+    /// supplied value.
+    ///
+    /// The read path uses this to seed the counter from the Lance
+    /// table version, which is persistent and monotonic across process
+    /// restarts. Unlike [`bump`](Self::bump), which produces a
+    /// process-local sequence that resets to 0 on restart, a value set
+    /// from the table version makes the cache key reproducible: the
+    /// same table state always yields the same generation, so a
+    /// recovered NVMe entry is only reachable when the namespace has
+    /// not changed since the entry was stored.
+    pub fn set(&self, ns: &NamespaceId, value: u64) {
+        self.inner
+            .entry(ns.clone())
+            .or_default()
+            .store(value, Ordering::Release);
+    }
 }
 
 #[cfg(test)]

--- a/crates/firnflow-core/src/cache/layer.rs
+++ b/crates/firnflow-core/src/cache/layer.rs
@@ -170,4 +170,16 @@ impl NamespaceCache {
     pub fn generation_counter(&self) -> Arc<GenerationCounter> {
         Arc::clone(&self.generations)
     }
+
+    /// Flush the NVMe write buffer and shut the cache down cleanly.
+    ///
+    /// Delegates to foyer's graceful shutdown so entries inserted before
+    /// the call are durable on disk. The cache must not be used after
+    /// this returns.
+    pub async fn close(&self) -> Result<(), FirnflowError> {
+        self.cache
+            .close()
+            .await
+            .map_err(|e| FirnflowError::Cache(format!("cache close: {e}")))
+    }
 }

--- a/crates/firnflow-core/src/cache/layer.rs
+++ b/crates/firnflow-core/src/cache/layer.rs
@@ -148,11 +148,32 @@ impl NamespaceCache {
         self.cache.insert(key, value);
     }
 
-    /// Invalidate every cache entry for a namespace.
+    /// Set the cache generation for a namespace to an externally
+    /// supplied value — in practice the Lance table version the
+    /// [`NamespaceManager`](crate::NamespaceManager) reports.
     ///
-    /// O(1): increments the namespace generation counter. Previously
-    /// cached entries remain in foyer's underlying store until LFU/LRU
-    /// reclaims them, but are no longer reachable by key.
+    /// The read path calls this before every lookup so the exact-cache
+    /// key (and the semantic sidecar, which shares this counter) is
+    /// derived from the persistent table version rather than a
+    /// process-local sequence. This is what lets recovered NVMe entries
+    /// survive a restart without being served stale: the version
+    /// reflects every committed write, so a key computed after a
+    /// restart matches a recovered entry only when the table has not
+    /// changed since that entry was stored.
+    pub fn set_generation(&self, ns: &NamespaceId, generation: u64) {
+        self.generations.set(ns, generation);
+    }
+
+    /// Invalidate every cache entry for a namespace by bumping the
+    /// generation counter.
+    ///
+    /// No longer driven by the write path — invalidation now follows
+    /// the Lance table version via [`set_generation`](Self::set_generation),
+    /// which advances on every commit. Retained as a primitive for the
+    /// generation-counter unit tests and any caller that needs an
+    /// explicit, process-local bump. Previously cached entries remain
+    /// in foyer's underlying store until LFU/LRU reclaims them, but are
+    /// no longer reachable by key.
     pub fn invalidate(&self, ns: &NamespaceId) -> u64 {
         self.generations.bump(ns)
     }

--- a/crates/firnflow-core/src/cache/semantic.rs
+++ b/crates/firnflow-core/src/cache/semantic.rs
@@ -16,22 +16,24 @@
 //!
 //! ## Invalidation
 //!
-//! Each namespace's entry list is stamped with the generation
-//! counter at insert time. Two routes invalidate them:
+//! Each namespace's entry list is stamped with the generation at
+//! insert time. The generation is the Lance table version, which the
+//! read path writes into the shared [`GenerationCounter`] (via
+//! `NamespaceCache::set_generation`) before every lookup. Two routes
+//! drop stale entries:
 //!
 //! 1. **Eager**: [`NamespaceService`](crate::NamespaceService) calls
-//!    [`SemanticCache::invalidate`] alongside the exact-cache
-//!    invalidation on every write/delete/compact. Same shape as
-//!    [`crate::cache::NamespaceCache::invalidate`].
-//! 2. **Lazy / defence-in-depth**: every lookup and insert reads
-//!    the current generation from the supplied
-//!    [`GenerationCounter`] and drops any stale list before
-//!    proceeding. This catches any path that bumps the generation
-//!    without notifying the sidecar.
+//!    [`SemanticCache::invalidate`] on every write/delete/compact to
+//!    free the memory immediately.
+//! 2. **Lazy / defence-in-depth**: every lookup and insert compares
+//!    the current generation against the list's stamp and drops a
+//!    stale list before proceeding.
 //!
-//! Index builds do **not** invalidate semantic entries — the
-//! underlying rows are unchanged and the cached top-k is still
-//! correct. This matches the exact-cache behaviour.
+//! Because the generation is the table version, **any** commit moves
+//! it — including index builds. So unlike the earlier design, an index
+//! build now drops the semantic entries on the next lookup, matching
+//! the exact cache: the rows are unchanged, but post-index queries
+//! re-run against the new index rather than replaying a cached top-k.
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -55,6 +55,7 @@ use object_store::aws::AmazonS3Builder;
 use object_store::gcp::GoogleCloudStorageBuilder;
 use object_store::path::Path as ObjectStorePath;
 use object_store::ObjectStore;
+use xxhash_rust::xxh3::xxh3_64;
 
 use crate::metrics::CoreMetrics;
 use crate::query::DEFAULT_NPROBES;
@@ -242,47 +243,66 @@ impl NamespaceManager {
         self.schema_info.get(ns).map(|r| r.has_ingested_at)
     }
 
-    /// Current cache generation for a namespace: the Lance table
-    /// version.
+    /// Current cache generation for a namespace: a deterministic hash
+    /// over the Lance manifest's `version` and commit `timestamp_nanos`.
     ///
-    /// The version advances on every commit — append, delete, index
-    /// build, compaction — and is persisted in the table manifest, so
-    /// it is identical across process restarts and across replicas
-    /// reading the same bucket. The result cache keys on this value so
-    /// a recovered NVMe entry is never served once the table it was
-    /// computed against has moved on.
+    /// The version advances on every commit (append, delete, index
+    /// build, compaction) and is persisted in the manifest, so it
+    /// survives a process restart — that is what stops a recovered NVMe
+    /// entry being served after a write. The commit timestamp is folded
+    /// in so that two incarnations of a namespace which reach the same
+    /// version after a delete-and-recreate still key differently: a
+    /// result cached against the deleted incarnation cannot be re-served
+    /// to the new one.
+    ///
+    /// This reflects only the version this process's handle has
+    /// observed. It is read from the cached handle without a
+    /// `checkout_latest`, so it does not necessarily see commits made by
+    /// another process; multi-replica cache coherence is out of scope
+    /// and Firn assumes a single replica per bucket.
     ///
     /// Returns `0` for a namespace that has no table yet (nothing has
-    /// been written). Lance table versions start at 1, so `0` can
-    /// never collide with a real version.
+    /// been written), which can never collide with a real generation.
     ///
-    /// Cheap on the hot path: when the namespace has a pooled handle,
-    /// `Table::version()` is an in-memory manifest read with no
-    /// object-store round-trip. A cold namespace pays one table-open —
-    /// the same cost a backend query would incur — and the handle is
-    /// then pooled. Never creates a table: a query against a
-    /// never-written namespace must not materialise one.
+    /// Cheap on the hot path: with a pooled handle the manifest is read
+    /// in memory with no object-store round-trip. A cold namespace pays
+    /// one table-open — the same cost a backend query would incur — and
+    /// the handle is then pooled. Never creates a table: a query against
+    /// a never-written namespace must not materialise one.
     pub async fn generation(&self, ns: &NamespaceId) -> Result<u64, FirnflowError> {
-        // Warm pool: read the version straight off the cached handle.
+        // Warm pool: read the manifest straight off the cached handle.
         // Clone the handle and drop the map guard before awaiting so we
         // never hold a DashMap reference across an `.await`.
         if let Some(entry) = self.handles.get(ns) {
             let tbl = entry.table.clone();
             drop(entry);
-            return tbl
-                .version()
-                .await
-                .map_err(|e| FirnflowError::Backend(format!("table.version: {e}")));
+            return Self::generation_of(&tbl).await;
         }
         // Cold: open the table if it exists (caching the handle), else
         // report generation 0 without creating anything.
         match self.open_existing(ns).await? {
-            Some((tbl, _info)) => tbl
-                .version()
-                .await
-                .map_err(|e| FirnflowError::Backend(format!("table.version: {e}"))),
+            Some((tbl, _info)) => Self::generation_of(&tbl).await,
             None => Ok(0),
         }
+    }
+
+    /// Hash an open table's manifest `(version, timestamp_nanos)` into a
+    /// `u64` cache generation. Both fields live in the in-memory
+    /// manifest, so on a warm handle this is an in-memory read.
+    async fn generation_of(tbl: &lancedb::Table) -> Result<u64, FirnflowError> {
+        let dataset = tbl
+            .dataset()
+            .ok_or_else(|| {
+                FirnflowError::Backend("generation requires a native lance table".into())
+            })?
+            .get()
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("resolve dataset: {e}")))?;
+        let manifest = dataset.manifest();
+        let mut buf = [0u8; 24];
+        buf[..8].copy_from_slice(&manifest.version.to_le_bytes());
+        buf[8..].copy_from_slice(&manifest.timestamp_nanos.to_le_bytes());
+        Ok(xxh3_64(&buf))
     }
 
     /// Number of namespaces currently holding a pooled

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -242,6 +242,49 @@ impl NamespaceManager {
         self.schema_info.get(ns).map(|r| r.has_ingested_at)
     }
 
+    /// Current cache generation for a namespace: the Lance table
+    /// version.
+    ///
+    /// The version advances on every commit — append, delete, index
+    /// build, compaction — and is persisted in the table manifest, so
+    /// it is identical across process restarts and across replicas
+    /// reading the same bucket. The result cache keys on this value so
+    /// a recovered NVMe entry is never served once the table it was
+    /// computed against has moved on.
+    ///
+    /// Returns `0` for a namespace that has no table yet (nothing has
+    /// been written). Lance table versions start at 1, so `0` can
+    /// never collide with a real version.
+    ///
+    /// Cheap on the hot path: when the namespace has a pooled handle,
+    /// `Table::version()` is an in-memory manifest read with no
+    /// object-store round-trip. A cold namespace pays one table-open —
+    /// the same cost a backend query would incur — and the handle is
+    /// then pooled. Never creates a table: a query against a
+    /// never-written namespace must not materialise one.
+    pub async fn generation(&self, ns: &NamespaceId) -> Result<u64, FirnflowError> {
+        // Warm pool: read the version straight off the cached handle.
+        // Clone the handle and drop the map guard before awaiting so we
+        // never hold a DashMap reference across an `.await`.
+        if let Some(entry) = self.handles.get(ns) {
+            let tbl = entry.table.clone();
+            drop(entry);
+            return tbl
+                .version()
+                .await
+                .map_err(|e| FirnflowError::Backend(format!("table.version: {e}")));
+        }
+        // Cold: open the table if it exists (caching the handle), else
+        // report generation 0 without creating anything.
+        match self.open_existing(ns).await? {
+            Some((tbl, _info)) => tbl
+                .version()
+                .await
+                .map_err(|e| FirnflowError::Backend(format!("table.version: {e}"))),
+            None => Ok(0),
+        }
+    }
+
     /// Number of namespaces currently holding a pooled
     /// `lancedb::Connection` + `lancedb::Table` handle. Mirrors the
     /// `firnflow_cached_handles` gauge and is exposed for tests

--- a/crates/firnflow-core/src/service.rs
+++ b/crates/firnflow-core/src/service.rs
@@ -149,18 +149,15 @@ impl NamespaceService {
     ///
     /// Removing the Lance table drops the namespace back to "no table"
     /// (generation 0 on the next read), so results cached against the
-    /// deleted table become unreachable. The semantic sidecar is
+    /// deleted table become unreachable. Recreating the namespace under
+    /// the same name is safe even though its Lance version restarts at
+    /// 1: the cache generation folds in the manifest commit timestamp
+    /// (see [`NamespaceManager::generation`](crate::NamespaceManager::generation)),
+    /// so the recreated incarnation keys differently from the deleted
+    /// one and cannot re-serve its cached bytes. The semantic sidecar is
     /// cleared eagerly. A failed delete leaves the cache serving the
     /// pre-delete entries, self-consistent with the data still sitting
     /// in object storage.
-    ///
-    /// Known edge: recreating a namespace with the same name within the
-    /// same process restarts its Lance version at 1, so a result cached
-    /// against the *deleted* incarnation at some version `v` could be
-    /// re-served if the new incarnation reaches the same `v` with an
-    /// identical query before that foyer entry is reclaimed. This is no
-    /// worse than the pre-fix restart behaviour and is tracked as a
-    /// follow-up; avoid immediately reusing a deleted namespace name.
     ///
     /// Returns the number of objects the manager removed.
     pub async fn delete(&self, ns: &NamespaceId) -> Result<usize, FirnflowError> {

--- a/crates/firnflow-core/src/service.rs
+++ b/crates/firnflow-core/src/service.rs
@@ -120,12 +120,15 @@ impl NamespaceService {
         &self.semantic
     }
 
-    /// Write path: append rows via the manager, then invalidate
-    /// every cached query result for this namespace. Invalidation
-    /// happens *after* the write succeeds so that a failed append
-    /// leaves the cache in a self-consistent state (worst case the
-    /// cache keeps returning pre-failure results until the next
-    /// successful write).
+    /// Write path: append rows via the manager. The append advances
+    /// the Lance table version, which is the cache generation, so the
+    /// next read derives a new generation and every result cached
+    /// against the pre-write version becomes unreachable — no explicit
+    /// cache bump is needed. Because the version only moves on a
+    /// successful commit, a failed append leaves the cache
+    /// self-consistent (it keeps serving the pre-failure results). The
+    /// semantic sidecar is cleared eagerly to free memory rather than
+    /// wait for its lazy generation-mismatch drop on the next lookup.
     ///
     /// Records `s3_requests_total{operation="upsert"}` eagerly (one
     /// per call) and `write_duration_seconds` on return.
@@ -137,27 +140,33 @@ impl NamespaceService {
         let start = Instant::now();
         self.metrics.record_s3_request(ns, "upsert");
         self.manager.upsert(ns, rows).await?;
-        self.cache.invalidate(ns);
         self.semantic.invalidate(ns);
         self.metrics.record_write(ns, start.elapsed().as_secs_f64());
         Ok(())
     }
 
-    /// Delete every object under the namespace prefix and invalidate
-    /// its cache entries.
+    /// Delete every object under the namespace prefix.
     ///
-    /// Same after-success ordering as [`upsert`](Self::upsert): the
-    /// manager-side S3 cleanup runs first, and only if it succeeds
-    /// do we bump the generation counter. A failed delete leaves
-    /// the cache serving the pre-delete entries, which is
-    /// self-consistent with the data still sitting in S3.
+    /// Removing the Lance table drops the namespace back to "no table"
+    /// (generation 0 on the next read), so results cached against the
+    /// deleted table become unreachable. The semantic sidecar is
+    /// cleared eagerly. A failed delete leaves the cache serving the
+    /// pre-delete entries, self-consistent with the data still sitting
+    /// in object storage.
     ///
-    /// Returns the number of S3 objects the manager removed.
+    /// Known edge: recreating a namespace with the same name within the
+    /// same process restarts its Lance version at 1, so a result cached
+    /// against the *deleted* incarnation at some version `v` could be
+    /// re-served if the new incarnation reaches the same `v` with an
+    /// identical query before that foyer entry is reclaimed. This is no
+    /// worse than the pre-fix restart behaviour and is tracked as a
+    /// follow-up; avoid immediately reusing a deleted namespace name.
+    ///
+    /// Returns the number of objects the manager removed.
     pub async fn delete(&self, ns: &NamespaceId) -> Result<usize, FirnflowError> {
         let start = Instant::now();
         self.metrics.record_s3_request(ns, "delete");
         let count = self.manager.delete(ns).await?;
-        self.cache.invalidate(ns);
         self.semantic.invalidate(ns);
         self.metrics.record_write(ns, start.elapsed().as_secs_f64());
         Ok(count)
@@ -201,6 +210,17 @@ impl NamespaceService {
         validate_semantic_cache_request(req)?;
 
         let query_hash = hash_query_for_cache(req)?;
+
+        // Derive the cache generation from the persistent Lance table
+        // version before consulting either layer. The in-process
+        // generation counter resets to 0 on restart; the table version
+        // does not, so seeding the counter from it makes a recovered
+        // NVMe entry reachable only when the namespace has not changed
+        // since the entry was stored. Both the exact cache and the
+        // semantic sidecar (which shares the counter) key off this
+        // value. Cheap on a warm handle — an in-memory manifest read.
+        let generation = self.manager.generation(ns).await?;
+        self.cache.set_generation(ns, generation);
 
         // 1. Exact cache — always consulted, opt-in or not.
         let (exact_hit, captured_generation) = self.cache.try_get(ns, query_hash).await;
@@ -303,10 +323,14 @@ impl NamespaceService {
     /// Records `firnflow_index_build_duration_seconds{namespace, kind}`
     /// on completion — the "Index Tax" metric.
     ///
-    /// Index build does **not** invalidate the cache. Cached results
-    /// are still correct post-build; the index is a structural
-    /// optimisation, not a data change. The semantic sidecar is
-    /// likewise left untouched.
+    /// Building an index is a Lance commit, so it advances the table
+    /// version and the next read derives a new generation: results
+    /// cached before the build become unreachable. This is a behaviour
+    /// change from the old generation-counter design, which left the
+    /// cache untouched on index builds. It is the safer default —
+    /// post-build queries run against the new index instead of
+    /// replaying a pre-index cached result — at the cost of dropping
+    /// the warm cache after an infrequent, operator-triggered build.
     pub async fn create_index(
         &self,
         ns: &NamespaceId,
@@ -339,8 +363,10 @@ impl NamespaceService {
     /// only). Records `firnflow_index_build_duration_seconds{kind="scalar"}`
     /// on completion.
     ///
-    /// Index build does **not** invalidate the cache: the index is
-    /// a pure read-path optimisation, the data underneath is unchanged.
+    /// Like the other index builders, this is a Lance commit, so it
+    /// advances the table version and the next read derives a new
+    /// generation — the warm cache is dropped even though the rows
+    /// themselves are unchanged. See [`create_index`](Self::create_index).
     pub async fn create_scalar_index(
         &self,
         ns: &NamespaceId,
@@ -356,16 +382,17 @@ impl NamespaceService {
 
     /// Compact the namespace's data files.
     ///
+    /// Compaction is a Lance commit, so it advances the table version
+    /// and the next read derives a new generation — results cached
+    /// against the pre-compaction version fall out of reach without an
+    /// explicit bump. The semantic sidecar is cleared eagerly.
+    ///
     /// Records `firnflow_compaction_duration_seconds{namespace}` on
-    /// completion. Invalidates both the exact cache and the semantic
-    /// sidecar after a successful compaction — the underlying data
-    /// files change, so cached result bytes may reference stale file
-    /// offsets.
+    /// completion.
     pub async fn compact(&self, ns: &NamespaceId) -> Result<CompactResult, FirnflowError> {
         let start = Instant::now();
         self.metrics.record_s3_request(ns, "compact");
         let result = self.manager.compact(ns).await?;
-        self.cache.invalidate(ns);
         self.semantic.invalidate(ns);
         self.metrics
             .record_compaction(ns, start.elapsed().as_secs_f64());

--- a/crates/firnflow-core/tests/cache_restart_staleness.rs
+++ b/crates/firnflow-core/tests/cache_restart_staleness.rs
@@ -1,0 +1,86 @@
+//! Restart-staleness repro for the per-namespace generation counter.
+//!
+//! The cache stays correct under writes by bumping an in-process
+//! generation counter (see the cache-invalidation decision record) so
+//! previously cached entries become unreachable by key. That counter
+//! lives only in memory (a `DashMap`) and resets to 0 when the process
+//! restarts. The foyer NVMe tier, however, persists across restarts and
+//! recovers its entries on reopen — foyer's disk engine defaults to
+//! `RecoverMode::Quiet`, which restores every readable entry.
+//!
+//! So after a restart two things are true at once: the generation
+//! sequence replays from 0, and the recovered NVMe entries still carry
+//! their pre-restart `(namespace, generation, query)` keys. A query whose
+//! replayed generation lands on a recovered key is served the pre-restart
+//! bytes — a stale read across the write that bumped the generation,
+//! which violates the invalidation invariant.
+//!
+//! This test simulates a restart by closing one `NamespaceCache` and
+//! building a second over the same NVMe directory. It asserts the
+//! correct behaviour: the post-restart lookup must miss. While the bug is
+//! live that assertion fails, so the test carries `#[ignore]`. Removing
+//! the ignore is the acceptance test for the fix.
+
+use firnflow_core::cache::{NamespaceCache, QueryHash};
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{FirnflowError, NamespaceId};
+
+const MEM_BYTES: usize = 16 * 1024 * 1024;
+const DISK_BYTES: usize = 64 * 1024 * 1024;
+
+#[tokio::test]
+#[ignore = "demonstrates the live stale-read-after-restart bug; un-ignore once the generation survives restart"]
+async fn restart_does_not_serve_pre_restart_entries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let nvme = tmp.path();
+
+    let ns = NamespaceId::new("acme").unwrap();
+    let query = QueryHash::of(b"select top 10 where x > 5");
+
+    // --- First process lifetime ---
+    let cache = NamespaceCache::new(MEM_BYTES, nvme, DISK_BYTES, test_metrics())
+        .await
+        .expect("build cache");
+
+    // A read at generation 0 caches the pre-write result.
+    let r1 = cache
+        .get_or_populate(&ns, query, || async {
+            Ok::<_, FirnflowError>(b"v1".to_vec())
+        })
+        .await
+        .unwrap();
+    assert_eq!(r1, b"v1");
+
+    // A write lands and invalidates the namespace (generation -> 1). The
+    // authoritative data is now "v2"; the gen-0 "v1" entry is stale.
+    cache.invalidate(&ns);
+
+    // In-process the stale gen-0 entry is already unreachable: the lookup
+    // keys at generation 1 and misses.
+    let (hit, gen) = cache.try_get(&ns, query).await;
+    assert_eq!(gen, 1, "the write should have advanced the generation to 1");
+    assert!(hit.is_none(), "post-write lookup must miss in-process");
+
+    // Flush the NVMe writer and shut down, as a clean restart would.
+    cache.close().await.expect("close cache");
+    drop(cache);
+
+    // --- Second process lifetime: same NVMe directory, fresh counter ---
+    let restarted = NamespaceCache::new(MEM_BYTES, nvme, DISK_BYTES, test_metrics())
+        .await
+        .expect("rebuild cache over the same NVMe dir");
+
+    // The generation counter reset to 0, so a repeat of the same query
+    // keys at generation 0 — exactly the key the recovered "v1" entry
+    // still carries on the NVMe tier.
+    let (hit, gen) = restarted.try_get(&ns, query).await;
+    assert_eq!(
+        gen, 0,
+        "a fresh process starts every namespace at generation 0"
+    );
+    assert!(
+        hit.is_none(),
+        "after a restart the cache must not serve pre-restart entries; got a recovered hit, \
+         which is a stale read across the write that bumped the generation"
+    );
+}

--- a/crates/firnflow-core/tests/cache_restart_staleness.rs
+++ b/crates/firnflow-core/tests/cache_restart_staleness.rs
@@ -1,25 +1,24 @@
-//! Restart-staleness repro for the per-namespace generation counter.
+//! Regression test for stale cache reads after a process restart.
 //!
-//! The cache stays correct under writes by bumping an in-process
-//! generation counter (see the cache-invalidation decision record) so
-//! previously cached entries become unreachable by key. That counter
-//! lives only in memory (a `DashMap`) and resets to 0 when the process
-//! restarts. The foyer NVMe tier, however, persists across restarts and
-//! recovers its entries on reopen — foyer's disk engine defaults to
-//! `RecoverMode::Quiet`, which restores every readable entry.
+//! The bug: the cache generation used to come from an in-memory counter
+//! that reset to 0 on restart, while the foyer NVMe tier persists and
+//! recovers its entries on reopen. After a restart the generation
+//! sequence replayed from 0 and re-synthesised keys that matched
+//! recovered entries from before a write, serving them as stale hits.
 //!
-//! So after a restart two things are true at once: the generation
-//! sequence replays from 0, and the recovered NVMe entries still carry
-//! their pre-restart `(namespace, generation, query)` keys. A query whose
-//! replayed generation lands on a recovered key is served the pre-restart
-//! bytes — a stale read across the write that bumped the generation,
-//! which violates the invalidation invariant.
+//! The fix derives the generation from the Lance table version — a
+//! persistent, monotonic value that advances on every commit. The read
+//! path writes that version into the cache via
+//! [`NamespaceCache::set_generation`] before every lookup, so a
+//! recovered NVMe entry is reachable only when the table has not
+//! changed since the entry was stored.
 //!
-//! This test simulates a restart by closing one `NamespaceCache` and
-//! building a second over the same NVMe directory. It asserts the
-//! correct behaviour: the post-restart lookup must miss. While the bug is
-//! live that assertion fails, so the test carries `#[ignore]`. Removing
-//! the ignore is the acceptance test for the fix.
+//! This test exercises the cache layer directly and stands in for the
+//! manager by calling `set_generation` with the version the manager
+//! would report: the same version across a simulated restart means "no
+//! writes happened" (the recovered entry is still valid and must hit);
+//! a higher version means "a write advanced the table" (the recovered
+//! entry is superseded and must miss).
 
 use firnflow_core::cache::{NamespaceCache, QueryHash};
 use firnflow_core::metrics::test_metrics;
@@ -28,21 +27,23 @@ use firnflow_core::{FirnflowError, NamespaceId};
 const MEM_BYTES: usize = 16 * 1024 * 1024;
 const DISK_BYTES: usize = 64 * 1024 * 1024;
 
+async fn build(nvme: &std::path::Path) -> NamespaceCache {
+    NamespaceCache::new(MEM_BYTES, nvme, DISK_BYTES, test_metrics())
+        .await
+        .expect("build cache")
+}
+
 #[tokio::test]
-#[ignore = "demonstrates the live stale-read-after-restart bug; un-ignore once the generation survives restart"]
-async fn restart_does_not_serve_pre_restart_entries() {
+async fn restart_does_not_serve_entries_from_a_superseded_version() {
     let tmp = tempfile::tempdir().unwrap();
     let nvme = tmp.path();
 
     let ns = NamespaceId::new("acme").unwrap();
     let query = QueryHash::of(b"select top 10 where x > 5");
 
-    // --- First process lifetime ---
-    let cache = NamespaceCache::new(MEM_BYTES, nvme, DISK_BYTES, test_metrics())
-        .await
-        .expect("build cache");
-
-    // A read at generation 0 caches the pre-write result.
+    // --- First process lifetime: cache a result at table version 1. ---
+    let cache = build(nvme).await;
+    cache.set_generation(&ns, 1);
     let r1 = cache
         .get_or_populate(&ns, query, || async {
             Ok::<_, FirnflowError>(b"v1".to_vec())
@@ -51,36 +52,34 @@ async fn restart_does_not_serve_pre_restart_entries() {
         .unwrap();
     assert_eq!(r1, b"v1");
 
-    // A write lands and invalidates the namespace (generation -> 1). The
-    // authoritative data is now "v2"; the gen-0 "v1" entry is stale.
-    cache.invalidate(&ns);
-
-    // In-process the stale gen-0 entry is already unreachable: the lookup
-    // keys at generation 1 and misses.
-    let (hit, gen) = cache.try_get(&ns, query).await;
-    assert_eq!(gen, 1, "the write should have advanced the generation to 1");
-    assert!(hit.is_none(), "post-write lookup must miss in-process");
-
     // Flush the NVMe writer and shut down, as a clean restart would.
     cache.close().await.expect("close cache");
     drop(cache);
 
-    // --- Second process lifetime: same NVMe directory, fresh counter ---
-    let restarted = NamespaceCache::new(MEM_BYTES, nvme, DISK_BYTES, test_metrics())
-        .await
-        .expect("rebuild cache over the same NVMe dir");
+    // --- Restart over the same NVMe directory. The in-memory counter is
+    //     gone; the recovered "v1" entry is still on disk. ---
+    let restarted = build(nvme).await;
 
-    // The generation counter reset to 0, so a repeat of the same query
-    // keys at generation 0 — exactly the key the recovered "v1" entry
-    // still carries on the NVMe tier.
-    let (hit, gen) = restarted.try_get(&ns, query).await;
-    assert_eq!(
-        gen, 0,
-        "a fresh process starts every namespace at generation 0"
-    );
+    // A write advanced the table to version 2 before/around the restart,
+    // so the manager now reports version 2. The recovered v1 entry was
+    // stored at version 1 and must not be served.
+    restarted.set_generation(&ns, 2);
+    let (hit, _) = restarted.try_get(&ns, query).await;
     assert!(
         hit.is_none(),
-        "after a restart the cache must not serve pre-restart entries; got a recovered hit, \
-         which is a stale read across the write that bumped the generation"
+        "after a write advanced the table version, the recovered v1 entry \
+         must not be served — that would be a stale read across the write"
+    );
+
+    // Control: keying at the original version 1 still finds the recovered
+    // entry. This proves the miss above came from the version check, not
+    // from a cold tier — the NVMe cache is genuinely reused across the
+    // restart when the table has not moved on.
+    restarted.set_generation(&ns, 1);
+    let (hit, _) = restarted.try_get(&ns, query).await;
+    assert_eq!(
+        hit.as_deref(),
+        Some(b"v1".as_slice()),
+        "an unchanged table (same version) must still serve its recovered entry"
     );
 }

--- a/crates/firnflow-core/tests/service_cache_aside.rs
+++ b/crates/firnflow-core/tests/service_cache_aside.rs
@@ -202,3 +202,96 @@ async fn service_cache_aside_follows_table_version() {
          step 4, and the new row from step 6"
     );
 }
+
+/// Deleting a namespace and recreating it under the same name must not
+/// serve the deleted incarnation's cached results, even when the new
+/// incarnation reaches the same Lance version. The generation folds in
+/// the manifest commit timestamp, so the two incarnations key
+/// differently. Regression for the delete/recreate collision.
+#[tokio::test]
+#[ignore]
+async fn delete_recreate_does_not_serve_old_incarnation() {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    let tmp = tempfile::tempdir().unwrap();
+    let metrics = test_metrics();
+    let manager = Arc::new(NamespaceManager::new(
+        StorageRoot::s3_bucket(&bucket).unwrap(),
+        minio_options(),
+        Arc::clone(&metrics),
+    ));
+    let cache = Arc::new(
+        NamespaceCache::new(
+            16 * 1024 * 1024,
+            tmp.path(),
+            64 * 1024 * 1024,
+            Arc::clone(&metrics),
+        )
+        .await
+        .expect("build cache"),
+    );
+    let service = NamespaceService::new(
+        Arc::clone(&manager),
+        Arc::clone(&cache),
+        Arc::clone(&metrics),
+    );
+
+    let ns = NamespaceId::new(unique_namespace("recreate")).unwrap();
+    let req = QueryRequest {
+        vector: unit_vector(0),
+        vectors: None,
+        k: 10,
+        nprobes: None,
+        text: None,
+        semantic_cache: None,
+    };
+
+    // --- Incarnation A: one row, then cache the query result. ---
+    service
+        .upsert(&ns, vec![UpsertRow::from((1, unit_vector(0)))])
+        .await
+        .expect("upsert A");
+    let a = service.query(&ns, &req).await.expect("query A");
+    assert_eq!(a.results.len(), 1, "incarnation A has one row");
+    let a_hit = service
+        .query_with_cache_source(&ns, &req)
+        .await
+        .expect("query A repeat");
+    assert_eq!(
+        a_hit.cache_source,
+        QueryCacheSource::ExactCache,
+        "incarnation A's result is cached before the delete"
+    );
+
+    // --- Delete, then recreate under the same name with different data.
+    //     Incarnation B reaches the same Lance version as A (create +
+    //     one upsert = version 2) but holds two different rows. ---
+    service.delete(&ns).await.expect("delete");
+    service
+        .upsert(
+            &ns,
+            vec![
+                UpsertRow::from((2, unit_vector(1))),
+                UpsertRow::from((3, unit_vector(2))),
+            ],
+        )
+        .await
+        .expect("upsert B");
+
+    // The same query must miss: the recreated incarnation keys
+    // differently from the deleted one despite the identical version.
+    let b = service
+        .query_with_cache_source(&ns, &req)
+        .await
+        .expect("query B");
+    assert_eq!(
+        b.cache_source,
+        QueryCacheSource::Backend,
+        "recreated namespace must miss the cache, not serve the deleted \
+         incarnation's bytes"
+    );
+    assert_eq!(
+        b.result.results.len(),
+        2,
+        "must reflect incarnation B's two rows, not incarnation A's one row"
+    );
+}

--- a/crates/firnflow-core/tests/service_cache_aside.rs
+++ b/crates/firnflow-core/tests/service_cache_aside.rs
@@ -1,20 +1,26 @@
 //! `NamespaceService` cache-aside cycle integration test.
 //!
-//! Proves the full loop:
+//! The cache generation is the Lance table version, so invalidation is
+//! intrinsic to the data: every committed write advances the version,
+//! and the next read derives a new cache key. There is no service-level
+//! "bump" to bypass, which means the classic "write through the manager
+//! to observe a stale read" trick no longer produces staleness — a
+//! manager-level write advances the version just the same. The cache is
+//! instead proven to be in the hot path via the reported
+//! [`QueryCacheSource`].
 //!
-//! 1. upsert via the service → rows land in Lance, cache is invalidated
-//! 2. query via the service → cache miss, manager runs the search,
-//!    result is serialised into foyer
-//! 3. query again → cache hit, no backend call, same bytes returned
-//! 4. *side-channel* upsert directly through the manager, bypassing
-//!    the service → the cache is intentionally not invalidated
-//! 5. query via the service → still a cache hit; stale result
-//!    returned (this is the whole point of step 4 — if it returned
-//!    fresh data here the cache would be a no-op and the test
-//!    wouldn't be testing invalidation at all)
-//! 6. upsert via the service once more → bumps the generation
-//! 7. query via the service → cache miss again, repopulates with
-//!    the fresh post-step-4 rows
+//! The loop:
+//!
+//! 1. upsert via the service → rows land in Lance (version advances)
+//! 2. query → cache miss (`Backend`), manager runs the search, result
+//!    serialised into foyer
+//! 3. query again → cache hit (`ExactCache`), no backend call, same hits
+//! 4. *side-channel* upsert directly through the manager → advances the
+//!    table version
+//! 5. query → cache miss (`Backend`) again, because the version moved;
+//!    the fresh row is reflected (no stale read, unlike the old design)
+//! 6. upsert via the service once more → version advances again
+//! 7. query → cache miss (`Backend`), repopulates with every row
 //!
 //! Gated `#[ignore]`: needs MinIO up.
 //!
@@ -30,7 +36,8 @@ use std::sync::Arc;
 use firnflow_core::cache::NamespaceCache;
 use firnflow_core::metrics::test_metrics;
 use firnflow_core::{
-    NamespaceId, NamespaceManager, NamespaceService, QueryRequest, StorageRoot, UpsertRow,
+    NamespaceId, NamespaceManager, NamespaceService, QueryCacheSource, QueryRequest, StorageRoot,
+    UpsertRow,
 };
 
 const DIM: usize = 8;
@@ -75,7 +82,7 @@ fn unit_vector(axis: usize) -> Vec<f32> {
 
 #[tokio::test]
 #[ignore]
-async fn service_cache_aside_invalidates_on_upsert() {
+async fn service_cache_aside_follows_table_version() {
     // ---- setup ----
     let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
     let tmp = tempfile::tempdir().unwrap();
@@ -124,46 +131,74 @@ async fn service_cache_aside_invalidates_on_upsert() {
         .expect("service.upsert initial");
 
     // ---- 2. first query: cache miss, populates with 2 hits ----
-    let r1 = service.query(&ns, &req).await.expect("query #1");
-    assert_eq!(r1.results.len(), 2, "step 2: expected 2 cached hits");
+    let r1 = service
+        .query_with_cache_source(&ns, &req)
+        .await
+        .expect("query #1");
+    assert_eq!(r1.cache_source, QueryCacheSource::Backend, "step 2: miss");
+    assert_eq!(r1.result.results.len(), 2, "step 2: expected 2 hits");
 
     // ---- 3. second query: cache hit, same 2 hits ----
-    let r2 = service.query(&ns, &req).await.expect("query #2");
-    assert_eq!(r2.results.len(), 2, "step 3: expected same 2 cached hits");
+    let r2 = service
+        .query_with_cache_source(&ns, &req)
+        .await
+        .expect("query #2");
     assert_eq!(
-        r1.results[0].id, r2.results[0].id,
-        "step 3: identical top hit across hit/miss"
+        r2.cache_source,
+        QueryCacheSource::ExactCache,
+        "step 3: identical repeat must be served from the exact cache — \
+         this is what proves the cache is in the hot path"
+    );
+    assert_eq!(r2.result.results.len(), 2, "step 3: same 2 cached hits");
+    assert_eq!(
+        r1.result.results[0].id, r2.result.results[0].id,
+        "step 3: identical top hit across miss/hit"
     );
 
-    // ---- 4. side-channel upsert via manager, bypassing the cache ----
+    // ---- 4. side-channel upsert via manager, bypassing the service ----
     manager
         .upsert(&ns, vec![UpsertRow::from((3, unit_vector(2)))])
         .await
         .expect("manager.upsert bypass");
 
-    // ---- 5. third query: still a cache hit, still 2 hits ----
-    let r3 = service.query(&ns, &req).await.expect("query #3");
+    // ---- 5. third query: cache miss again — the manager write advanced
+    //         the table version, so the generation changed and the fresh
+    //         row is reflected. Under the old generation-counter design
+    //         this returned the stale 2-result set; version-derived
+    //         generation makes the bypass write visible. ----
+    let r3 = service
+        .query_with_cache_source(&ns, &req)
+        .await
+        .expect("query #3");
     assert_eq!(
-        r3.results.len(),
-        2,
-        "step 5: cache must still serve the stale 2-result set, \
-         not the fresh 3-row table. If this fails, the cache is \
-         a no-op and the test is not exercising invalidation."
+        r3.cache_source,
+        QueryCacheSource::Backend,
+        "step 5: a manager-level write advances the table version, so the \
+         next read misses the cache and reflects the new row"
+    );
+    assert_eq!(
+        r3.result.results.len(),
+        3,
+        "step 5: the bypass row is visible — no stale read"
     );
 
-    // ---- 6. upsert via service: bumps generation, evicts stale ----
+    // ---- 6. upsert via service: advances the version again ----
     service
         .upsert(&ns, vec![UpsertRow::from((4, unit_vector(3)))])
         .await
         .expect("service.upsert invalidating");
 
     // ---- 7. fourth query: cache miss, repopulates with all 4 ----
-    let r4 = service.query(&ns, &req).await.expect("query #4");
+    let r4 = service
+        .query_with_cache_source(&ns, &req)
+        .await
+        .expect("query #4");
+    assert_eq!(r4.cache_source, QueryCacheSource::Backend, "step 7: miss");
     assert_eq!(
-        r4.results.len(),
+        r4.result.results.len(),
         4,
-        "step 7: after invalidation the cache must repopulate and \
-         surface every row — the two from step 1, the bypass row \
-         from step 4, and the new row from step 6."
+        "step 7: after the version advanced the cache repopulates and \
+         surfaces every row — the two from step 1, the bypass row from \
+         step 4, and the new row from step 6"
     );
 }


### PR DESCRIPTION
## Summary

The result cache keyed entries on a per-namespace generation counter held only in memory, which reset to 0 on restart while the foyer NVMe tier persists and recovers its entries on reopen. After a restart the generation sequence replayed from 0 and re-synthesised keys that matched recovered entries from before a write, so a repeat query could be served a result from before a write that had already bumped the generation.

This derives the generation from the Lance table version instead. `NamespaceManager::generation` reads `Table::version` (persisted in the manifest, advances on every commit), and the query read path writes it into the shared counter via `NamespaceCache::set_generation` before each lookup, so a recovered NVMe entry is reachable only when the table has not changed since the entry was stored. `version()` is an in-memory manifest read on a warm pooled handle, so the hot path stays cheap; a cold namespace pays one table-open, the same cost a backend query would. An in-process `add` advances the shared dataset wrapper, so a pooled handle's version reflects an upsert without eviction and same-process write-then-read stays correct.

The first commit adds the failing repro; the second implements the fix and un-ignores it.

## Behavior notes

Invalidation is now intrinsic to the version, so the explicit cache bumps on write/delete/compact are gone; the semantic sidecar is still cleared eagerly to free memory.

Building an index (IVF_PQ, FTS, or scalar BTree) now invalidates a namespace's cached results, where before it left them untouched. An index build is a Lance commit, so it advances the version. This is the safer default, since post-build queries run against the new index instead of replaying a pre-index result, and index builds are infrequent and operator-triggered.

Known edge, no worse than before: deleting and recreating a namespace with the same name restarts its Lance version at 1, so a result cached against the deleted incarnation at version `v` could be re-served if the new incarnation reaches the same `v` with an identical query before that foyer entry is reclaimed. There is no cheap per-incarnation identifier in lancedb and no per-namespace foyer purge, so this is documented on `delete` as a follow-up rather than fixed here.

`service_cache_aside.rs` is reworked to prove the cache is in the hot path via the reported cache source rather than by observing a stale read, since a manager-level write now advances the version too and is correctly reflected.

## Tests

~~~text
cargo fmt --all -- --check
cargo clippy -p firnflow-core --all-targets -- -D warnings
cargo test -p firnflow-core --test cache_restart_staleness --test cache_invalidation
~~~

`cache_restart_staleness` (un-ignored) and `cache_invalidation` pass. The MinIO-gated tests (`service_cache_aside`, the `manager_*` suite) compile under the clippy run but were not executed on this branch — they need the local MinIO stack (`docker compose up -d minio minio-init`), which was not run here. `cargo test --workspace` was deliberately skipped on this disk-tight host.

Refs #13.
