### PR TITLE
Add a namespace info endpoint (GET /ns/{namespace})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `GET /ns/{namespace}` returns namespace metadata: vector kind and dimension, live row count, fragment count, which index kinds are built (vector / FTS / scalar), and the current Lance table version. Read/write tier, bypasses the cache (it is namespace state, not a query result), and records a `firnflow_s3_requests_total{operation="info"}` tick so the backend read stays visible in the cost signal. Returns 404 only for a genuinely missing table; storage or auth failures surface as 5xx rather than a misleading "namespace does not exist". Closes #14.
+
 ## [0.8.1] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ curl -X POST http://localhost:3000/ns/demo/upsert \
 | :--- | :--- | :--- | :--- |
 | `/health` | `GET` | open | Liveness check |
 | `/metrics` | `GET` | metrics or open | Prometheus exposition format |
+| `/ns/{ns}` | `GET` | read/write | Namespace metadata (row count, fragment count, indexes, table version); 404 if it has no data yet |
 | `/ns/{ns}` | `DELETE` | admin | Removes all data (object storage + cache) for a namespace |
 | `/ns/{ns}/upsert` | `POST` | read/write | Append vectors and data (not deduplicated by `id`) |
 | `/ns/{ns}/query` | `POST` | read/write | Vector, FTS, or hybrid search |

--- a/crates/firnflow-api/src/error.rs
+++ b/crates/firnflow-api/src/error.rs
@@ -19,11 +19,14 @@ use firnflow_core::FirnflowError;
 
 /// API error variants. `Core` wraps a `firnflow-core` error and
 /// inherits its existing 4xx/5xx mapping. `Unauthorized`,
-/// `Forbidden`, and `RateLimited` are API-layer-only.
+/// `Forbidden`, `NotFound`, and `RateLimited` are API-layer-only.
 pub enum ApiError {
     Core(FirnflowError),
     Unauthorized,
     Forbidden,
+    /// The addressed resource does not exist (e.g. metadata for a
+    /// namespace that has never been written). Renders as 404.
+    NotFound(String),
     RateLimited(Duration),
 }
 
@@ -63,6 +66,9 @@ impl IntoResponse for ApiError {
                 }),
             )
                 .into_response(),
+            ApiError::NotFound(msg) => {
+                (StatusCode::NOT_FOUND, Json(ErrorBody { error: msg })).into_response()
+            }
             ApiError::RateLimited(wait) => {
                 let secs = wait.as_secs().max(1);
                 let mut response = (

--- a/crates/firnflow-api/src/handlers.rs
+++ b/crates/firnflow-api/src/handlers.rs
@@ -4,6 +4,7 @@
 //! * `POST   /ns/{namespace}/upsert`
 //! * `POST   /ns/{namespace}/query`
 //! * `GET    /ns/{namespace}/list`
+//! * `GET    /ns/{namespace}`
 //! * `DELETE /ns/{namespace}`
 //! * `POST   /ns/{namespace}/warmup`
 //! * `POST   /ns/{namespace}/index`
@@ -23,7 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use firnflow_core::{
     decode_list_cursor, FirnflowError, IndexRequest, ListOrder, ListPage, NamespaceId,
-    QueryRequest, UpsertRow as CoreUpsertRow, LIST_MAX_LIMIT,
+    NamespaceInfo, QueryRequest, UpsertRow as CoreUpsertRow, LIST_MAX_LIMIT,
 };
 
 use crate::error::ApiError;
@@ -456,6 +457,25 @@ pub async fn list(
 
     let page = state.manager.list(&ns, limit, order, cursor).await?;
     Ok(Json(page))
+}
+
+/// Return operational metadata for a namespace: vector kind and
+/// dimension, row count, fragment count, which index kinds are built,
+/// and the current table version.
+///
+/// Like `/list`, this bypasses the foyer cache and calls
+/// `state.manager.info(...)` directly — it is namespace state, not a
+/// query result, so caching it would only risk staleness. Returns 404
+/// when the namespace has never been written.
+pub async fn info(
+    State(state): State<AppState>,
+    Path(namespace): Path<String>,
+) -> Result<Json<NamespaceInfo>, ApiError> {
+    let ns = NamespaceId::new(namespace)?;
+    match state.manager.info(&ns).await? {
+        Some(info) => Ok(Json(info)),
+        None => Err(ApiError::NotFound(format!("namespace {ns} does not exist"))),
+    }
 }
 
 /// Prometheus scrape endpoint. Serialises the process-wide

--- a/crates/firnflow-api/src/lib.rs
+++ b/crates/firnflow-api/src/lib.rs
@@ -37,7 +37,8 @@ pub use state::{build_state, AppState};
 ///   [`auth::require_metrics_token`], which short-circuits when no
 ///   `FIRNFLOW_METRICS_TOKEN` is configured (preserving the
 ///   pre-0.5.0 default-public behaviour).
-/// * **Read/Write** — `upsert`, `query`, `list`, `warmup`. Stacks
+/// * **Read/Write** — `upsert`, `query`, `list`, `warmup`, and the
+///   `GET /ns/{namespace}` metadata endpoint. Stacks
 ///   `require_write` and the per-principal limiter inside a single
 ///   `ServiceBuilder` so the limiter sees the `Principal` extension
 ///   that auth attaches.
@@ -69,7 +70,11 @@ pub fn router(state: AppState) -> Router {
         .route("/ns/{namespace}/upsert", post(handlers::upsert))
         .route("/ns/{namespace}/query", post(handlers::query))
         .route("/ns/{namespace}/list", get(handlers::list))
-        .route("/ns/{namespace}/warmup", post(handlers::warmup));
+        .route("/ns/{namespace}/warmup", post(handlers::warmup))
+        // GET /ns/{namespace} (namespace metadata) shares its path with
+        // the admin-tier DELETE; axum merges the two method routers
+        // since the methods differ, and each keeps its own auth layer.
+        .route("/ns/{namespace}", get(handlers::info));
     // ServiceBuilder applies layers top-to-bottom: auth first
     // (attaches the Principal extension), principal limiter second
     // (reads it). `axum::Router::layer` then mounts the whole stack

--- a/crates/firnflow-api/tests/api_namespace_info.rs
+++ b/crates/firnflow-api/tests/api_namespace_info.rs
@@ -1,0 +1,140 @@
+//! Integration test for `GET /ns/{namespace}` (issue #14).
+//!
+//! Drives the axum router via `tower::ServiceExt::oneshot`. Covers the
+//! happy path (metadata shape after an upsert) and the 404 for a
+//! namespace that has never been written. Index-flag transitions are
+//! covered at the manager layer (`tests/manager_namespace_info.rs`),
+//! where index builds are synchronous; the API index endpoints return
+//! 202 and build in the background, which would race a read here.
+//!
+//! Gated `#[ignore]`: needs MinIO up.
+
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use firnflow_api::router;
+use firnflow_core::CoreMetrics;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+mod common;
+use common::{test_state, unique_namespace};
+
+async fn build_app() -> (axum::Router, Arc<CoreMetrics>, tempfile::TempDir) {
+    let (state, tmp) = test_state().await;
+    let metrics = Arc::clone(&state.metrics);
+    (router(state), metrics, tmp)
+}
+
+async fn post_json(app: axum::Router, uri: String, body: Value) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, json)
+}
+
+async fn get(app: axum::Router, uri: String) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, json)
+}
+
+async fn metrics_text(app: axum::Router) -> String {
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+#[ignore]
+async fn info_returns_namespace_metadata() {
+    let (app, _metrics, _tmp) = build_app().await;
+    let ns = unique_namespace("api-info");
+
+    let body = json!({
+        "rows": [
+            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]},
+            {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0]},
+            {"id": 3, "vector": [0.0, 0.0, 1.0, 0.0]},
+        ]
+    });
+    let (status, _) = post_json(app.clone(), format!("/ns/{ns}/upsert"), body).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, info) = get(app.clone(), format!("/ns/{ns}")).await;
+    assert_eq!(status, StatusCode::OK, "info body: {info}");
+    assert_eq!(info["namespace"].as_str().unwrap(), ns);
+    assert_eq!(info["kind"].as_str().unwrap(), "single");
+    assert_eq!(info["vector_dim"].as_u64().unwrap(), 4);
+    assert_eq!(info["row_count"].as_u64().unwrap(), 3);
+    assert!(info["fragment_count"].as_u64().unwrap() >= 1);
+    assert_eq!(info["has_vector_index"], json!(false));
+    assert_eq!(info["has_fts_index"], json!(false));
+    assert_eq!(info["has_scalar_index"], json!(false));
+    assert!(
+        info["table_version"].as_u64().unwrap() >= 1,
+        "table version advances on commits"
+    );
+
+    // The metadata read bypasses NamespaceService, so the manager
+    // records the backend hit itself; confirm it lands on the cost
+    // counter under operation="info".
+    let metrics = metrics_text(app).await;
+    let info_ticks: u64 = metrics
+        .lines()
+        .filter(|l| l.starts_with("firnflow_s3_requests_total") && l.contains("operation=\"info\""))
+        .filter_map(|l| l.split_whitespace().last())
+        .filter_map(|v| v.parse::<f64>().ok())
+        .map(|v| v as u64)
+        .sum();
+    assert!(
+        info_ticks >= 1,
+        "GET /ns/{{ns}} should record an s3_requests_total{{operation=\"info\"}} tick"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn info_404_for_unknown_namespace() {
+    let (app, _metrics, _tmp) = build_app().await;
+    let ns = unique_namespace("api-info-missing");
+
+    let (status, body) = get(app, format!("/ns/{ns}")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("does not exist"),
+        "expected a not-found message, got {body}"
+    );
+}

--- a/crates/firnflow-core/src/lib.rs
+++ b/crates/firnflow-core/src/lib.rs
@@ -28,7 +28,7 @@ pub use query::{
     effective_semantic_threshold, validate_ivf_pq_options, validate_semantic_cache_request,
     IndexRequest, QueryRequest, SemanticCacheRequest, DEFAULT_SEMANTIC_MIN_SIMILARITY,
 };
-pub use result::{ListOrder, ListPage, ListRow, QueryResult, QueryResultSet};
+pub use result::{ListOrder, ListPage, ListRow, NamespaceInfo, QueryResult, QueryResultSet};
 pub use service::{NamespaceService, QueryCacheSource, QueryOutcome};
 pub use storage_root::{Scheme, StorageRoot};
 pub use vector::VectorKind;

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -47,7 +47,7 @@ use futures::{StreamExt, TryStreamExt};
 use lance::dataset::scanner::ColumnOrdering;
 use lancedb::index::scalar::{BTreeIndexBuilder, FtsIndexBuilder, FullTextSearchQuery};
 use lancedb::index::vector::IvfPqIndexBuilder;
-use lancedb::index::Index;
+use lancedb::index::{Index, IndexType};
 use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::table::OptimizeAction;
 use lancedb::DistanceType;
@@ -59,7 +59,7 @@ use xxhash_rust::xxh3::xxh3_64;
 
 use crate::metrics::CoreMetrics;
 use crate::query::DEFAULT_NPROBES;
-use crate::result::{ListOrder, ListPage, ListRow};
+use crate::result::{ListOrder, ListPage, ListRow, NamespaceInfo};
 use crate::storage_root::Scheme;
 use crate::vector::VectorKind;
 use crate::{FirnflowError, NamespaceId, QueryResult, QueryResultSet, StorageRoot};
@@ -462,7 +462,12 @@ impl NamespaceManager {
                 self.cache_handle(ns, conn, tbl.clone());
                 Ok(Some((tbl, info)))
             }
-            Err(_) => Ok(None),
+            // Only a genuine "table does not exist" means the namespace
+            // has no data. Storage, auth, and transient errors must
+            // propagate as backend errors, not be misreported as a
+            // missing namespace (the `info` endpoint maps `None` to 404).
+            Err(lancedb::Error::TableNotFound { .. }) => Ok(None),
+            Err(e) => Err(FirnflowError::Backend(format!("open table {ns}: {e}"))),
         }
     }
 
@@ -1143,6 +1148,89 @@ impl NamespaceManager {
 
         Ok(ListPage { rows, next_cursor })
     }
+
+    /// Gather operational metadata for a namespace without running a
+    /// query: vector kind and dimension, live row count, fragment
+    /// count, which index kinds are built, and the current table
+    /// version.
+    ///
+    /// Returns `Ok(None)` when the namespace has no table yet (nothing
+    /// has been written) so the API layer can answer 404. Never creates
+    /// a table. `count_rows` and `list_indices` read table metadata on
+    /// the backend, so this is a metadata round-trip and is
+    /// deliberately not cached.
+    pub async fn info(&self, ns: &NamespaceId) -> Result<Option<NamespaceInfo>, FirnflowError> {
+        // This path opens the table and reads its metadata directly,
+        // bypassing NamespaceService, so record the backend hit here —
+        // same as `/list` — to keep `firnflow_s3_requests_total` an
+        // honest count of Firn-initiated object-store operations.
+        self.metrics.record_s3_request(ns, "info");
+
+        let Some((tbl, schema)) = self.open_existing(ns).await? else {
+            return Ok(None);
+        };
+
+        let row_count = tbl
+            .count_rows(None)
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("count_rows: {e}")))?;
+
+        let indices = tbl
+            .list_indices()
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("list_indices: {e}")))?;
+        let (has_vector_index, has_fts_index, has_scalar_index) =
+            classify_index_types(indices.iter().map(|i| i.index_type.clone()));
+
+        // Fragment count and table version come from the in-memory
+        // manifest on the (now pooled) handle — no extra round-trip.
+        let dataset = tbl
+            .dataset()
+            .ok_or_else(|| {
+                FirnflowError::Backend("namespace info requires a native lance table".into())
+            })?
+            .get()
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("resolve dataset: {e}")))?;
+        let manifest = dataset.manifest();
+
+        Ok(Some(NamespaceInfo {
+            namespace: ns.to_string(),
+            kind: schema.kind,
+            vector_dim: schema.dim,
+            row_count,
+            fragment_count: manifest.fragments.len(),
+            has_vector_index,
+            has_fts_index,
+            has_scalar_index,
+            table_version: manifest.version,
+        }))
+    }
+}
+
+/// Classify a namespace's built indexes into `(vector, fts, scalar)`
+/// presence flags. The IVF / HNSW family are vector indexes, `FTS` is
+/// the BM25 full-text index, and BTree / bitmap / label-list are scalar
+/// indexes. Exhaustive over [`IndexType`] on purpose: a new Lance index
+/// kind will fail to compile here until it is classified deliberately.
+fn classify_index_types(types: impl Iterator<Item = IndexType>) -> (bool, bool, bool) {
+    let mut vector = false;
+    let mut fts = false;
+    let mut scalar = false;
+    for ty in types {
+        match ty {
+            IndexType::IvfFlat
+            | IndexType::IvfSq
+            | IndexType::IvfPq
+            | IndexType::IvfRq
+            | IndexType::IvfHnswPq
+            | IndexType::IvfHnswSq
+            | IndexType::IvfHnswFlat => vector = true,
+            IndexType::FTS => fts = true,
+            IndexType::BTree | IndexType::Bitmap | IndexType::LabelList => scalar = true,
+        }
+    }
+    (vector, fts, scalar)
 }
 
 /// Encode a `(timestamp_micros, id)` pair as a 32-character hex
@@ -1585,5 +1673,27 @@ mod tests {
     #[test]
     fn cursor_rejects_non_hex() {
         assert!(decode_list_cursor(&"z".repeat(32)).is_err());
+    }
+
+    #[test]
+    fn classify_index_types_buckets_by_family() {
+        // No indexes: all false.
+        assert_eq!(classify_index_types([].into_iter()), (false, false, false));
+
+        // One of each family.
+        assert_eq!(
+            classify_index_types([IndexType::IvfPq, IndexType::FTS, IndexType::BTree].into_iter()),
+            (true, true, true)
+        );
+
+        // HNSW variants count as vector; bitmap / label-list as scalar.
+        assert_eq!(
+            classify_index_types([IndexType::IvfHnswSq].into_iter()),
+            (true, false, false)
+        );
+        assert_eq!(
+            classify_index_types([IndexType::Bitmap, IndexType::LabelList].into_iter()),
+            (false, false, true)
+        );
     }
 }

--- a/crates/firnflow-core/src/result.rs
+++ b/crates/firnflow-core/src/result.rs
@@ -9,6 +9,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::vector::VectorKind;
+
 /// A single search hit.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QueryResult {
@@ -77,4 +79,36 @@ pub struct ListPage {
     /// Opaque cursor to pass as `?cursor=` on the next call, or
     /// `None` if no further rows are available in the chosen order.
     pub next_cursor: Option<String>,
+}
+
+/// Operational metadata for a namespace, returned by
+/// `GET /ns/{namespace}`.
+///
+/// Read directly from the Lance table — it is namespace state, not a
+/// query result, so it is never cached.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NamespaceInfo {
+    /// Namespace name.
+    pub namespace: String,
+    /// Vector representation: `"single"` or `"multivector"`.
+    pub kind: VectorKind,
+    /// Vector dimension. For multivector namespaces this is the inner
+    /// sub-vector width.
+    pub vector_dim: usize,
+    /// Live row count (`Table::count_rows`). Note that without
+    /// idempotent upsert (see issue #31), re-sending a row id appends
+    /// another row, so this counts physical rows, not distinct ids.
+    pub row_count: usize,
+    /// Number of Lance data fragments. A growing count is the signal
+    /// to `POST /ns/{namespace}/compact`.
+    pub fragment_count: usize,
+    /// Whether a vector index (the IVF_PQ / HNSW family) is built.
+    pub has_vector_index: bool,
+    /// Whether a BM25 full-text index is built on the `text` column.
+    pub has_fts_index: bool,
+    /// Whether a scalar index (BTree / bitmap / label-list) is built.
+    pub has_scalar_index: bool,
+    /// Current Lance table version. Advances on every commit; this is
+    /// the value the result cache derives its generation from.
+    pub table_version: u64,
 }

--- a/crates/firnflow-core/tests/manager_namespace_info.rs
+++ b/crates/firnflow-core/tests/manager_namespace_info.rs
@@ -1,0 +1,119 @@
+//! Integration test for `NamespaceManager::info` (issue #14).
+//!
+//! Builds indexes synchronously at the manager layer so the index
+//! flags can be asserted without racing a background task. Covers the
+//! "no table yet" (None / 404 at the API) case, the metadata shape
+//! after an upsert, and the scalar + FTS index flags flipping to true
+//! after a build. Vector-index classification is exercised by the unit
+//! test on `classify_index_types`.
+//!
+//! Gated `#[ignore]`: needs MinIO up.
+
+use std::collections::HashMap;
+
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{NamespaceId, NamespaceManager, StorageRoot, UpsertRow, VectorKind};
+
+const DIM: usize = 4;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn unique_namespace(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "aws_access_key_id".into(),
+            env_or("FIRNFLOW_S3_ACCESS_KEY", "minioadmin"),
+        ),
+        (
+            "aws_secret_access_key".into(),
+            env_or("FIRNFLOW_S3_SECRET_KEY", "minioadmin"),
+        ),
+        (
+            "aws_endpoint".into(),
+            env_or("FIRNFLOW_S3_ENDPOINT", "http://127.0.0.1:9000"),
+        ),
+        ("aws_region".into(), "us-east-1".into()),
+        ("allow_http".into(), "true".into()),
+        ("aws_virtual_hosted_style_request".into(), "false".into()),
+    ])
+}
+
+fn manager() -> NamespaceManager {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    NamespaceManager::new(
+        StorageRoot::s3_bucket(&bucket).unwrap(),
+        minio_options(),
+        test_metrics(),
+    )
+}
+
+fn row(id: u64, axis: usize, text: &str) -> UpsertRow {
+    let mut vector = vec![0.0_f32; DIM];
+    vector[axis] = 1.0;
+    UpsertRow {
+        id,
+        vector,
+        vectors: None,
+        text: Some(text.to_string()),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn info_reports_namespace_state_and_index_flags() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("info")).unwrap();
+
+    // A namespace with no table yet has no info — the API maps this to 404.
+    assert!(
+        mgr.info(&ns).await.unwrap().is_none(),
+        "namespace with no data should report no info"
+    );
+
+    mgr.upsert(
+        &ns,
+        vec![row(1, 0, "alpha"), row(2, 1, "beta"), row(3, 2, "gamma")],
+    )
+    .await
+    .expect("upsert");
+
+    let info = mgr
+        .info(&ns)
+        .await
+        .unwrap()
+        .expect("namespace exists after upsert");
+    assert_eq!(info.namespace, ns.to_string());
+    assert_eq!(info.kind, VectorKind::Single);
+    assert_eq!(info.vector_dim, DIM);
+    assert_eq!(info.row_count, 3);
+    assert!(info.fragment_count >= 1, "at least one data fragment");
+    assert!(!info.has_vector_index);
+    assert!(!info.has_fts_index);
+    assert!(!info.has_scalar_index);
+    assert!(info.table_version >= 1, "version advances on commits");
+
+    // Both builds are synchronous at the manager layer.
+    mgr.create_scalar_index(&ns, "_ingested_at")
+        .await
+        .expect("scalar index");
+    mgr.create_fts_index(&ns).await.expect("fts index");
+
+    let after = mgr.info(&ns).await.unwrap().expect("still exists");
+    assert!(after.has_scalar_index, "scalar index should now be present");
+    assert!(after.has_fts_index, "fts index should now be present");
+    assert_eq!(after.row_count, 3, "index builds do not change row count");
+    assert!(
+        after.table_version > info.table_version,
+        "each index build is a commit that advances the version"
+    );
+}

--- a/docs/api.html
+++ b/docs/api.html
@@ -326,6 +326,58 @@
       </div>
     </div>
 
+    <!-- GET /ns/{ns} -->
+    <div class="endpoint">
+      <div class="endpoint-header" aria-expanded="true">
+        <span class="method method-get">GET</span>
+        <span class="endpoint-path">/ns/{namespace}</span>
+        <span class="endpoint-desc">Namespace metadata</span>
+      </div>
+      <div class="endpoint-body">
+        <p>Returns operational metadata for a namespace: its vector shape, live row count, fragment count, which index kinds are built, and the current Lance table version. Useful for dashboards and for deciding when to compact or build an index, without querying the data or inspecting raw objects.</p>
+        <p>Like <code>/list</code>, this bypasses the foyer cache; it is namespace state, not a query result. It never creates a table, so a namespace that has never been written returns 404.</p>
+
+        <h4>Response (200)</h4>
+        <table>
+          <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>namespace</code></td><td>string</td><td>Namespace name</td></tr>
+            <tr><td><code>kind</code></td><td>string</td><td><code>single</code> or <code>multivector</code></td></tr>
+            <tr><td><code>vector_dim</code></td><td>integer</td><td>Vector dimension (inner sub-vector width for multivector namespaces)</td></tr>
+            <tr><td><code>row_count</code></td><td>integer</td><td>Live row count. Counts physical rows; until idempotent upsert lands, re-using an <code>id</code> adds a row</td></tr>
+            <tr><td><code>fragment_count</code></td><td>integer</td><td>Number of Lance data fragments. A growing count is the cue to compact</td></tr>
+            <tr><td><code>has_vector_index</code></td><td>bool</td><td>Whether an IVF_PQ / HNSW vector index is built</td></tr>
+            <tr><td><code>has_fts_index</code></td><td>bool</td><td>Whether a BM25 full-text index is built</td></tr>
+            <tr><td><code>has_scalar_index</code></td><td>bool</td><td>Whether a BTree / bitmap / label-list scalar index is built</td></tr>
+            <tr><td><code>table_version</code></td><td>u64</td><td>Current Lance table version; advances on every commit</td></tr>
+          </tbody>
+        </table>
+
+        <h4>Status codes</h4>
+        <table>
+          <thead><tr><th>Code</th><th>When</th></tr></thead>
+          <tbody>
+            <tr><td>200</td><td>Success</td></tr>
+            <tr><td>404</td><td>Namespace has no data yet (no Lance table exists)</td></tr>
+          </tbody>
+        </table>
+
+        <h4>Example</h4>
+        <pre><code>curl http://localhost:3000/ns/demo</code></pre>
+        <pre><code>{
+  "namespace": "demo",
+  "kind": "single",
+  "vector_dim": 1536,
+  "row_count": 100000,
+  "fragment_count": 3,
+  "has_vector_index": true,
+  "has_fts_index": false,
+  "has_scalar_index": false,
+  "table_version": 42
+}</code></pre>
+      </div>
+    </div>
+
     <!-- DELETE /ns/{ns} -->
     <div class="endpoint">
       <div class="endpoint-header" aria-expanded="true">


### PR DESCRIPTION
## Summary

A read-only `GET /ns/{namespace}` that returns operational metadata for a namespace, so operators can answer "how many rows, which indexes, how many fragments?" without querying the data or inspecting raw objects. It returns the vector kind and dimension, live row count, fragment count, which index kinds are built (vector / FTS / scalar), and the current Lance table version.

`NamespaceManager::info` reads it straight from the table: `count_rows` for the row count, `list_indices` classified by family for the index flags, and the manifest for fragment count and version. It opens the table without creating one; only a genuine table-not-found is reported as "no namespace" (404), while storage, auth, and transient open failures surface as backend errors. That hardening lives in the shared open path, so `query`, `upsert`, and `list` also stop treating a transient open failure as an empty namespace. Like `/list`, the endpoint bypasses the foyer cache and records its own `firnflow_s3_requests_total{operation="info"}` tick so the backend read stays visible in the cost signal.

## Behavior notes

`GET /ns/{namespace}` sits in the read/write tier and shares its path with the admin-tier `DELETE /ns/{namespace}`; axum merges the two method routers because the methods differ, and each keeps its own auth layer. A namespace that has never been written returns 404; storage or auth failures return 5xx, not a misleading 404. Index classification is exhaustive over lancedb's `IndexType`, so a new Lance index kind will not compile until it is classified deliberately.

## Tests

~~~text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p firnflow-core --lib                                       # 55 passed (incl. classify_index_types)
# MinIO-gated, against the local docker-compose stack:
cargo test -p firnflow-core --test manager_namespace_info -- --ignored  # 1 passed
cargo test -p firnflow-api  --test api_namespace_info     -- --ignored  # 2 passed
~~~

The MinIO-gated tests cover the metadata shape, the scalar and FTS index flags flipping after a build, the `operation="info"` cost-metric tick, and the 404 for an unknown namespace.

Closes #14.
