### PR TITLE
Add a background-operation status endpoint (GET /operations/{id})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `GET /ns/{namespace}` returns namespace metadata: vector kind and dimension, live row count, fragment count, which index kinds are built (vector / FTS / scalar), and the current Lance table version. Read/write tier, bypasses the cache (it is namespace state, not a query result), and records a `firnflow_s3_requests_total{operation="info"}` tick so the backend read stays visible in the cost signal. Returns 404 only for a genuinely missing table; storage or auth failures surface as 5xx rather than a misleading "namespace does not exist". Closes #14.
+- `GET /operations/{operation_id}` reports the state of background work started by the async endpoints. Each of `warmup`, `index`, `fts-index`, `scalar-index`, and `compact` now returns an opaque `operation_id` in its `202`, and the operation moves `running` to `succeeded` or `failed`, with start/finish timestamps and a concise error message on failure. Records are in-memory and bounded — the most recent completed operations are retained and running ones are never evicted — so an unknown or evicted id returns 404. Read/write tier. The existing build/compaction duration metrics are unchanged. Closes #34.
+
+### Changed
+- The async endpoints (`warmup`, `index`, `fts-index`, `scalar-index`, `compact`) now return `{ operation_id, kind, namespace, status }` in their `202 Accepted` instead of a `{ "status": "... queued" }` confirmation; warmup additionally keeps its `queued` count. Clients should poll `GET /operations/{operation_id}` for completion rather than scraping the duration histograms.
 
 ## [0.8.1] - 2026-06-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,6 +2548,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
+ "dashmap",
  "firnflow-core",
  "governor",
  "serde",
@@ -2559,6 +2560,7 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ bincode = { version = "2", features = ["serde"] }
 # Concurrent collections.
 dashmap = "6"
 
+# Time-sortable opaque identifiers for background operation handles.
+uuid = { version = "1", features = ["v7"] }
+
 # Hashing.
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ curl -X POST http://localhost:3000/ns/demo/upsert \
 | `/ns/{ns}/fts-index` | `POST` | admin | Build BM25 full-text search index (async, returns 202) |
 | `/ns/{ns}/scalar-index` | `POST` | admin | Build BTree index on `_ingested_at` to accelerate `/list` (async, returns 202) |
 | `/ns/{ns}/compact` | `POST` | admin | Compact and prune data files (async, returns 202) |
+| `/operations/{id}` | `GET` | read/write | Status of a background operation by the `operation_id` from its 202; 404 if unknown or evicted |
+
+The async endpoints (`warmup`, `index`, `fts-index`, `scalar-index`, `compact`) return an opaque `operation_id` in their `202`; poll `GET /operations/{id}` to see whether the work is `running`, `succeeded`, or `failed` instead of inferring it from metrics.
 
 Auth column: `open` = no header required; `read/write` = `FIRNFLOW_API_KEY` (or `FIRNFLOW_ADMIN_API_KEY`); `admin` = `FIRNFLOW_ADMIN_API_KEY` if configured, otherwise `FIRNFLOW_API_KEY` via the single-key fallback. `/metrics` is `metrics` when `FIRNFLOW_METRICS_TOKEN` is set, otherwise `open`.
 

--- a/crates/firnflow-api/Cargo.toml
+++ b/crates/firnflow-api/Cargo.toml
@@ -25,6 +25,8 @@ tower.workspace = true
 tower_governor.workspace = true
 governor.workspace = true
 subtle.workspace = true
+dashmap.workspace = true
+uuid.workspace = true
 firnflow-core = { path = "../firnflow-core" }
 
 [dev-dependencies]

--- a/crates/firnflow-api/src/handlers.rs
+++ b/crates/firnflow-api/src/handlers.rs
@@ -11,6 +11,7 @@
 //! * `POST   /ns/{namespace}/fts-index`
 //! * `POST   /ns/{namespace}/scalar-index`
 //! * `POST   /ns/{namespace}/compact`
+//! * `GET    /operations/{operation_id}`
 //! * `GET    /metrics`
 
 use std::sync::Arc;
@@ -28,6 +29,7 @@ use firnflow_core::{
 };
 
 use crate::error::ApiError;
+use crate::operations::{OperationKind, OperationRecord, OperationStatus};
 use crate::state::AppState;
 
 const CACHE_SOURCE_REQUEST_HEADER: &str = "x-firn-debug-cache-source";
@@ -51,13 +53,29 @@ pub struct WarmupRequest {
     pub queries: Vec<QueryRequest>,
 }
 
-/// Body of a successful warmup response (HTTP 202 Accepted). The
-/// number is how many queries the background task was *asked*
-/// to run, not how many actually succeeded by the time the
-/// response is returned — the task runs after the response is
-/// sent.
+/// Body of the `202 Accepted` returned by every endpoint that starts
+/// background work. The `operation_id` is an opaque, pollable handle;
+/// fetch its current state from `GET /operations/{operation_id}`.
 #[derive(Debug, Serialize)]
-pub struct WarmupResponse {
+pub struct OperationAccepted {
+    /// Opaque handle for the background work; poll it for status.
+    pub operation_id: String,
+    /// What kind of operation was started.
+    pub kind: OperationKind,
+    /// Namespace the work targets.
+    pub namespace: String,
+    /// Lifecycle state at acceptance time (always `running` in v1).
+    pub status: OperationStatus,
+}
+
+/// Warmup's `202` body: the standard operation handle plus the number
+/// of queries the background task was asked to run (not how many had
+/// completed by the time the response was sent).
+#[derive(Debug, Serialize)]
+pub struct WarmupAccepted {
+    #[serde(flatten)]
+    pub operation: OperationAccepted,
+    /// Number of queries the background task was asked to run.
     pub queued: usize,
 }
 
@@ -186,14 +204,23 @@ pub async fn warmup(
     State(state): State<AppState>,
     Path(namespace): Path<String>,
     Json(req): Json<WarmupRequest>,
-) -> Result<(StatusCode, Json<WarmupResponse>), ApiError> {
+) -> Result<(StatusCode, Json<WarmupAccepted>), ApiError> {
     let ns = NamespaceId::new(namespace)?;
     let queued = req.queries.len();
 
+    let operation_id = state
+        .operations
+        .start(OperationKind::Warmup, ns.to_string());
+
     let service = Arc::clone(&state.service);
+    let operations = Arc::clone(&state.operations);
     let ns_owned = ns.clone();
     let queries = req.queries;
+    let op_for_task = operation_id.clone();
     tokio::spawn(async move {
+        let total = queries.len();
+        let mut failures = 0usize;
+        let mut first_error: Option<String> = None;
         for (idx, query) in queries.iter().enumerate() {
             if let Err(e) = service.query(&ns_owned, query).await {
                 tracing::warn!(
@@ -202,32 +229,56 @@ pub async fn warmup(
                     error = %e,
                     "warmup query failed"
                 );
+                failures += 1;
+                if first_error.is_none() {
+                    first_error = Some(operation_error_message(&e));
+                }
             }
+        }
+        // Every query is attempted regardless of individual failures, but
+        // the operation only reports `succeeded` if all of them warmed. If
+        // any failed it reports `failed` with a count and the first
+        // message, so a poller does not read `succeeded` when nothing was
+        // actually cached.
+        if failures == 0 {
+            operations.succeed(&op_for_task);
+        } else {
+            operations.fail(
+                &op_for_task,
+                format!(
+                    "{failures} of {total} warmup queries failed; first error: {}",
+                    first_error.unwrap_or_else(|| "operation failed".into())
+                ),
+            );
         }
     });
 
-    Ok((StatusCode::ACCEPTED, Json(WarmupResponse { queued })))
-}
-
-/// Body of a successful index build response (HTTP 202 Accepted).
-#[derive(Debug, Serialize)]
-pub struct IndexResponse {
-    /// Confirmation that the build was queued.
-    pub status: String,
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(WarmupAccepted {
+            operation: OperationAccepted {
+                operation_id,
+                kind: OperationKind::Warmup,
+                namespace: ns.to_string(),
+                status: OperationStatus::Running,
+            },
+            queued,
+        }),
+    ))
 }
 
 /// Explicit ANN index build.
 ///
 /// Spawns a background task that builds an IVF_PQ index on the
-/// namespace's vector column and returns `202 Accepted` immediately.
-/// Same fire-and-forget pattern as warmup. Operators monitor the
-/// `firnflow_index_build_duration_seconds` histogram to know when
-/// the build completes.
+/// namespace's vector column and returns `202 Accepted` with an
+/// `operation_id`. Poll `GET /operations/{operation_id}` for
+/// completion, or watch the `firnflow_index_build_duration_seconds`
+/// histogram.
 pub async fn create_index(
     State(state): State<AppState>,
     Path(namespace): Path<String>,
     Json(req): Json<IndexRequest>,
-) -> Result<(StatusCode, Json<IndexResponse>), ApiError> {
+) -> Result<(StatusCode, Json<OperationAccepted>), ApiError> {
     let ns = NamespaceId::new(namespace)?;
 
     if req.kind != "ivf_pq" {
@@ -247,10 +298,14 @@ pub async fn create_index(
     firnflow_core::validate_ivf_pq_options(req.num_bits, req.num_sub_vectors)
         .map_err(ApiError::Core)?;
 
+    let operation_id = state.operations.start(OperationKind::Index, ns.to_string());
+
     let service = Arc::clone(&state.service);
+    let operations = Arc::clone(&state.operations);
     let ns_owned = ns.clone();
+    let op_for_task = operation_id.clone();
     tokio::spawn(async move {
-        if let Err(e) = service
+        match service
             .create_index(
                 &ns_owned,
                 req.num_partitions,
@@ -259,54 +314,75 @@ pub async fn create_index(
             )
             .await
         {
-            tracing::error!(
-                namespace = %ns_owned,
-                error = %e,
-                "index build failed"
-            );
+            Ok(()) => operations.succeed(&op_for_task),
+            Err(e) => {
+                tracing::error!(
+                    namespace = %ns_owned,
+                    error = %e,
+                    "index build failed"
+                );
+                operations.fail(&op_for_task, operation_error_message(&e));
+            }
         }
     });
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(IndexResponse {
-            status: "index build queued".into(),
+        Json(OperationAccepted {
+            operation_id,
+            kind: OperationKind::Index,
+            namespace: ns.to_string(),
+            status: OperationStatus::Running,
         }),
     ))
 }
 
 /// Build a BM25 full-text search index on the namespace's `text`
-/// column. Same 202-async pattern as vector index build.
+/// column. Same 202-with-`operation_id` pattern as the vector index
+/// build; poll `GET /operations/{operation_id}` for completion.
 pub async fn create_fts_index(
     State(state): State<AppState>,
     Path(namespace): Path<String>,
-) -> Result<(StatusCode, Json<IndexResponse>), ApiError> {
+) -> Result<(StatusCode, Json<OperationAccepted>), ApiError> {
     let ns = NamespaceId::new(namespace)?;
 
+    let operation_id = state
+        .operations
+        .start(OperationKind::FtsIndex, ns.to_string());
+
     let service = Arc::clone(&state.service);
+    let operations = Arc::clone(&state.operations);
     let ns_owned = ns.clone();
+    let op_for_task = operation_id.clone();
     tokio::spawn(async move {
-        if let Err(e) = service.create_fts_index(&ns_owned).await {
-            tracing::error!(
-                namespace = %ns_owned,
-                error = %e,
-                "FTS index build failed"
-            );
+        match service.create_fts_index(&ns_owned).await {
+            Ok(()) => operations.succeed(&op_for_task),
+            Err(e) => {
+                tracing::error!(
+                    namespace = %ns_owned,
+                    error = %e,
+                    "FTS index build failed"
+                );
+                operations.fail(&op_for_task, operation_error_message(&e));
+            }
         }
     });
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(IndexResponse {
-            status: "fts index build queued".into(),
+        Json(OperationAccepted {
+            operation_id,
+            kind: OperationKind::FtsIndex,
+            namespace: ns.to_string(),
+            status: OperationStatus::Running,
         }),
     ))
 }
 
-/// Build a BTree scalar index on `_ingested_at`. Same 202-async
-/// pattern as `/fts-index`. The build runs in a tokio task; operators
-/// monitor `firnflow_index_build_duration_seconds{kind="scalar"}` for
-/// completion.
+/// Build a BTree scalar index on `_ingested_at`. Same
+/// 202-with-`operation_id` pattern as `/fts-index`; poll
+/// `GET /operations/{operation_id}` for completion, or watch
+/// `firnflow_index_build_duration_seconds{kind="scalar"}`.
 ///
 /// v1 hardcodes the column to `_ingested_at` to mirror the same
 /// constraint `/list` puts on `order_by`. Future user-column ordering
@@ -314,50 +390,62 @@ pub async fn create_fts_index(
 pub async fn create_scalar_index(
     State(state): State<AppState>,
     Path(namespace): Path<String>,
-) -> Result<(StatusCode, Json<IndexResponse>), ApiError> {
+) -> Result<(StatusCode, Json<OperationAccepted>), ApiError> {
     let ns = NamespaceId::new(namespace)?;
 
+    let operation_id = state
+        .operations
+        .start(OperationKind::ScalarIndex, ns.to_string());
+
     let service = Arc::clone(&state.service);
+    let operations = Arc::clone(&state.operations);
     let ns_owned = ns.clone();
+    let op_for_task = operation_id.clone();
     tokio::spawn(async move {
-        if let Err(e) = service.create_scalar_index(&ns_owned, "_ingested_at").await {
-            tracing::error!(
-                namespace = %ns_owned,
-                error = %e,
-                "scalar index build failed"
-            );
+        match service.create_scalar_index(&ns_owned, "_ingested_at").await {
+            Ok(()) => operations.succeed(&op_for_task),
+            Err(e) => {
+                tracing::error!(
+                    namespace = %ns_owned,
+                    error = %e,
+                    "scalar index build failed"
+                );
+                operations.fail(&op_for_task, operation_error_message(&e));
+            }
         }
     });
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(IndexResponse {
-            status: "scalar index build queued".into(),
+        Json(OperationAccepted {
+            operation_id,
+            kind: OperationKind::ScalarIndex,
+            namespace: ns.to_string(),
+            status: OperationStatus::Running,
         }),
     ))
 }
 
-/// Body of a successful compact response (HTTP 202 Accepted).
-#[derive(Debug, Serialize)]
-pub struct CompactResponse {
-    /// Confirmation that the compaction was queued.
-    pub status: String,
-}
-
 /// Explicit compaction.
 ///
-/// Spawns a background task that merges small data files into
-/// fewer, larger ones and returns `202 Accepted` immediately.
-/// Operators monitor the `firnflow_compaction_duration_seconds`
-/// histogram to know when the compaction completes.
+/// Spawns a background task that merges small data files into fewer,
+/// larger ones and returns `202 Accepted` with an `operation_id`. Poll
+/// `GET /operations/{operation_id}` for completion, or watch the
+/// `firnflow_compaction_duration_seconds` histogram.
 pub async fn compact(
     State(state): State<AppState>,
     Path(namespace): Path<String>,
-) -> Result<(StatusCode, Json<CompactResponse>), ApiError> {
+) -> Result<(StatusCode, Json<OperationAccepted>), ApiError> {
     let ns = NamespaceId::new(namespace)?;
 
+    let operation_id = state
+        .operations
+        .start(OperationKind::Compact, ns.to_string());
+
     let service = Arc::clone(&state.service);
+    let operations = Arc::clone(&state.operations);
     let ns_owned = ns.clone();
+    let op_for_task = operation_id.clone();
     tokio::spawn(async move {
         match service.compact(&ns_owned).await {
             Ok(result) => {
@@ -367,6 +455,7 @@ pub async fn compact(
                     fragments_added = result.fragments_added,
                     "compaction complete"
                 );
+                operations.succeed(&op_for_task);
             }
             Err(e) => {
                 tracing::error!(
@@ -374,14 +463,18 @@ pub async fn compact(
                     error = %e,
                     "compaction failed"
                 );
+                operations.fail(&op_for_task, operation_error_message(&e));
             }
         }
     });
 
     Ok((
         StatusCode::ACCEPTED,
-        Json(CompactResponse {
-            status: "compaction queued".into(),
+        Json(OperationAccepted {
+            operation_id,
+            kind: OperationKind::Compact,
+            namespace: ns.to_string(),
+            status: OperationStatus::Running,
         }),
     ))
 }
@@ -478,6 +571,22 @@ pub async fn info(
     }
 }
 
+/// Return the current state of a background operation by its
+/// `operation_id` (returned in the 202 from warmup, index, fts-index,
+/// scalar-index, and compact). Returns 404 if the id is unknown or its
+/// record has been evicted from the bounded in-memory registry.
+pub async fn get_operation(
+    State(state): State<AppState>,
+    Path(operation_id): Path<String>,
+) -> Result<Json<OperationRecord>, ApiError> {
+    match state.operations.get(&operation_id) {
+        Some(record) => Ok(Json(record)),
+        None => Err(ApiError::NotFound(format!(
+            "operation {operation_id} not found"
+        ))),
+    }
+}
+
 /// Prometheus scrape endpoint. Serialises the process-wide
 /// [`CoreMetrics`] registry into the Prometheus text exposition
 /// format with a `text/plain; version=0.0.4` content type.
@@ -487,4 +596,57 @@ pub async fn metrics(State(state): State<AppState>) -> Result<impl IntoResponse,
         [(CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")],
         body,
     ))
+}
+
+/// Map a background-task error to a concise, client-facing message for
+/// an operation record. This mirrors the synchronous API error policy
+/// in [`crate::error`]: validation and capability errors carry a
+/// caller-actionable message and are surfaced, while backend, cache,
+/// I/O, and metrics failures can embed storage or provider internals
+/// and are collapsed to a generic message. The full error is always
+/// preserved in the server logs via `tracing` at the call site.
+fn operation_error_message(err: &FirnflowError) -> String {
+    match err {
+        FirnflowError::InvalidNamespace(msg) => format!("invalid namespace: {msg}"),
+        FirnflowError::InvalidRequest(msg) => format!("invalid request: {msg}"),
+        FirnflowError::Unsupported(msg) => format!("unsupported: {msg}"),
+        FirnflowError::Backend(_)
+        | FirnflowError::Cache(_)
+        | FirnflowError::Io(_)
+        | FirnflowError::Metrics(_) => "operation failed".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_error_message_surfaces_caller_errors() {
+        let msg = operation_error_message(&FirnflowError::Unsupported(
+            "namespace predates the _ingested_at column".into(),
+        ));
+        assert!(
+            msg.contains("namespace predates the _ingested_at column"),
+            "capability errors should reach the caller, got: {msg}"
+        );
+
+        let msg = operation_error_message(&FirnflowError::InvalidRequest(
+            "num_sub_vectors must divide the dimension".into(),
+        ));
+        assert!(msg.contains("num_sub_vectors must divide the dimension"));
+    }
+
+    #[test]
+    fn operation_error_message_scrubs_backend_internals() {
+        let leaky = FirnflowError::Backend(
+            "s3://secret-bucket/ns: AccessDenied request-id 0xDEADBEEF".into(),
+        );
+        let msg = operation_error_message(&leaky);
+        assert_eq!(msg, "operation failed");
+        assert!(
+            !msg.contains("secret-bucket"),
+            "backend internals must not leak into the operation record"
+        );
+    }
 }

--- a/crates/firnflow-api/src/lib.rs
+++ b/crates/firnflow-api/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod auth;
 pub mod config;
 pub mod error;
+pub mod operations;
 pub mod rate_limit;
 pub mod state;
 
@@ -37,8 +38,9 @@ pub use state::{build_state, AppState};
 ///   [`auth::require_metrics_token`], which short-circuits when no
 ///   `FIRNFLOW_METRICS_TOKEN` is configured (preserving the
 ///   pre-0.5.0 default-public behaviour).
-/// * **Read/Write** — `upsert`, `query`, `list`, `warmup`, and the
-///   `GET /ns/{namespace}` metadata endpoint. Stacks
+/// * **Read/Write** — `upsert`, `query`, `list`, `warmup`, the
+///   `GET /ns/{namespace}` metadata endpoint, and the
+///   `GET /operations/{id}` background-operation status endpoint. Stacks
 ///   `require_write` and the per-principal limiter inside a single
 ///   `ServiceBuilder` so the limiter sees the `Principal` extension
 ///   that auth attaches.
@@ -74,7 +76,10 @@ pub fn router(state: AppState) -> Router {
         // GET /ns/{namespace} (namespace metadata) shares its path with
         // the admin-tier DELETE; axum merges the two method routers
         // since the methods differ, and each keeps its own auth layer.
-        .route("/ns/{namespace}", get(handlers::info));
+        .route("/ns/{namespace}", get(handlers::info))
+        // Background-operation status. Read-tier: the opaque operation
+        // id is the capability, and warmup (read-tier) creates one too.
+        .route("/operations/{operation_id}", get(handlers::get_operation));
     // ServiceBuilder applies layers top-to-bottom: auth first
     // (attaches the Principal extension), principal limiter second
     // (reads it). `axum::Router::layer` then mounts the whole stack

--- a/crates/firnflow-api/src/operations.rs
+++ b/crates/firnflow-api/src/operations.rs
@@ -1,0 +1,259 @@
+//! In-memory registry for background API operations (issue #34).
+//!
+//! The async endpoints (`warmup`, `index`, `fts-index`, `scalar-index`,
+//! `compact`) accept work, return `202 Accepted`, and run it in a
+//! `tokio::spawn`. This registry gives each of those a first-class,
+//! pollable handle: an opaque `operation_id` returned in the 202, and a
+//! `GET /operations/{id}` status endpoint backed by the records here.
+//!
+//! Records are ephemeral — process-local, never persisted — and bounded:
+//! only the most recent [`DEFAULT_MAX_COMPLETED`] completed operations
+//! are kept, while running operations are never evicted. The public
+//! shape is deliberately small so a future durable or clustered job
+//! store could replace the backing without changing the API.
+//!
+//! ## Lifecycle
+//!
+//! V1 is `Running -> Succeeded | Failed`. There is no `Queued` because
+//! the spawn model has no real queue (an op would sit "queued" for
+//! microseconds), and no `Cancelled` because there is no cancellation
+//! API. Both can be added later without a breaking change.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use serde::Serialize;
+use uuid::Uuid;
+
+/// Default cap on retained completed (succeeded / failed) operations.
+/// Running operations are never counted against this.
+pub const DEFAULT_MAX_COMPLETED: usize = 256;
+
+/// The kind of background work an operation tracks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationKind {
+    /// Cache warmup (`POST /ns/{ns}/warmup`).
+    Warmup,
+    /// IVF_PQ vector index build (`POST /ns/{ns}/index`).
+    Index,
+    /// BM25 full-text index build (`POST /ns/{ns}/fts-index`).
+    FtsIndex,
+    /// BTree scalar index build (`POST /ns/{ns}/scalar-index`).
+    ScalarIndex,
+    /// Compaction (`POST /ns/{ns}/compact`).
+    Compact,
+}
+
+/// Lifecycle state of a tracked operation. See the module docs for why
+/// `queued` and `cancelled` are intentionally absent in v1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OperationStatus {
+    /// The background task is in flight.
+    Running,
+    /// The work completed successfully.
+    Succeeded,
+    /// The work returned an error (see [`OperationRecord::error`]).
+    Failed,
+}
+
+/// A snapshot of a tracked operation, returned by the status endpoint.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct OperationRecord {
+    /// Opaque, time-sortable identifier. Clients must not parse it.
+    pub operation_id: String,
+    /// What kind of work this operation is.
+    pub kind: OperationKind,
+    /// Namespace the work targets.
+    pub namespace: String,
+    /// Current lifecycle state.
+    pub status: OperationStatus,
+    /// Milliseconds since the Unix epoch when the work began.
+    pub started_at_ms: u64,
+    /// Milliseconds since the Unix epoch when it reached a terminal
+    /// state; `null` while still running.
+    pub finished_at_ms: Option<u64>,
+    /// Concise, client-facing failure message; `null` unless failed.
+    /// Detailed diagnostics stay in the server logs.
+    pub error: Option<String>,
+}
+
+/// In-memory, bounded registry of background operations.
+pub struct OperationRegistry {
+    records: DashMap<String, OperationRecord>,
+    /// Completion order of terminal operations, used to evict the
+    /// oldest once `max_completed` is exceeded.
+    completed: Mutex<VecDeque<String>>,
+    max_completed: usize,
+}
+
+impl OperationRegistry {
+    /// Registry with the default completed-operation cap.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_MAX_COMPLETED)
+    }
+
+    /// Registry with a custom completed-operation cap (tests use a small
+    /// cap to exercise eviction without thousands of inserts).
+    pub fn with_capacity(max_completed: usize) -> Self {
+        Self {
+            records: DashMap::new(),
+            completed: Mutex::new(VecDeque::new()),
+            max_completed: max_completed.max(1),
+        }
+    }
+
+    /// Register a new operation as `running` and return its opaque id.
+    pub fn start(&self, kind: OperationKind, namespace: String) -> String {
+        let operation_id = format!("op_{}", Uuid::now_v7());
+        let record = OperationRecord {
+            operation_id: operation_id.clone(),
+            kind,
+            namespace,
+            status: OperationStatus::Running,
+            started_at_ms: now_ms(),
+            finished_at_ms: None,
+            error: None,
+        };
+        self.records.insert(operation_id.clone(), record);
+        operation_id
+    }
+
+    /// Mark an operation succeeded.
+    pub fn succeed(&self, operation_id: &str) {
+        self.finish(operation_id, OperationStatus::Succeeded, None);
+    }
+
+    /// Mark an operation failed with a concise client-facing message.
+    pub fn fail(&self, operation_id: &str, error: impl Into<String>) {
+        self.finish(operation_id, OperationStatus::Failed, Some(error.into()));
+    }
+
+    fn finish(&self, operation_id: &str, status: OperationStatus, error: Option<String>) {
+        {
+            let Some(mut rec) = self.records.get_mut(operation_id) else {
+                // Already evicted or never registered — nothing to do.
+                return;
+            };
+            rec.status = status;
+            rec.finished_at_ms = Some(now_ms());
+            rec.error = error;
+        }
+        // Record the completion and evict the oldest terminal records
+        // beyond the cap. Running operations never enter this queue, so
+        // they are never evicted.
+        let mut order = self
+            .completed
+            .lock()
+            .expect("operation registry mutex poisoned");
+        order.push_back(operation_id.to_string());
+        while order.len() > self.max_completed {
+            if let Some(old) = order.pop_front() {
+                self.records.remove(&old);
+            }
+        }
+    }
+
+    /// Snapshot of an operation, or `None` if the id is unknown or its
+    /// record has been evicted.
+    pub fn get(&self, operation_id: &str) -> Option<OperationRecord> {
+        self.records.get(operation_id).map(|r| r.clone())
+    }
+}
+
+impl Default for OperationRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_then_succeed_and_fail() {
+        let reg = OperationRegistry::new();
+
+        let ok = reg.start(OperationKind::ScalarIndex, "n1".into());
+        assert!(ok.starts_with("op_"), "ids are prefixed and opaque");
+        let rec = reg.get(&ok).unwrap();
+        assert_eq!(rec.kind, OperationKind::ScalarIndex);
+        assert_eq!(rec.namespace, "n1");
+        assert_eq!(rec.status, OperationStatus::Running);
+        assert!(rec.finished_at_ms.is_none());
+        assert!(rec.error.is_none());
+
+        reg.succeed(&ok);
+        let rec = reg.get(&ok).unwrap();
+        assert_eq!(rec.status, OperationStatus::Succeeded);
+        assert!(rec.finished_at_ms.is_some());
+        assert!(rec.error.is_none());
+
+        let bad = reg.start(OperationKind::Index, "n2".into());
+        reg.fail(&bad, "index training failed");
+        let rec = reg.get(&bad).unwrap();
+        assert_eq!(rec.status, OperationStatus::Failed);
+        assert_eq!(rec.error.as_deref(), Some("index training failed"));
+    }
+
+    #[test]
+    fn unknown_id_is_none() {
+        let reg = OperationRegistry::new();
+        assert!(reg.get("op_nonexistent").is_none());
+    }
+
+    #[test]
+    fn ids_are_unique() {
+        let reg = OperationRegistry::new();
+        let a = reg.start(OperationKind::Compact, "n".into());
+        let b = reg.start(OperationKind::Compact, "n".into());
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn completed_ops_are_evicted_beyond_cap() {
+        let reg = OperationRegistry::with_capacity(2);
+        let a = reg.start(OperationKind::Warmup, "n".into());
+        let b = reg.start(OperationKind::Warmup, "n".into());
+        let c = reg.start(OperationKind::Warmup, "n".into());
+        reg.succeed(&a);
+        reg.succeed(&b);
+        reg.succeed(&c);
+        // Oldest completed (a) is evicted; the two newest survive.
+        assert!(
+            reg.get(&a).is_none(),
+            "oldest completed op should be evicted"
+        );
+        assert!(reg.get(&b).is_some());
+        assert!(reg.get(&c).is_some());
+    }
+
+    #[test]
+    fn running_ops_are_never_evicted() {
+        let reg = OperationRegistry::with_capacity(1);
+        let running = reg.start(OperationKind::Index, "n".into());
+        let a = reg.start(OperationKind::Warmup, "n".into());
+        let b = reg.start(OperationKind::Warmup, "n".into());
+        reg.succeed(&a);
+        reg.succeed(&b);
+        // The cap (1) evicts completed `a`, but the still-running op is
+        // untouched even though it is older.
+        assert!(
+            reg.get(&running).is_some(),
+            "running op must not be evicted"
+        );
+        assert!(reg.get(&a).is_none());
+        assert!(reg.get(&b).is_some());
+    }
+}

--- a/crates/firnflow-api/src/state.rs
+++ b/crates/firnflow-api/src/state.rs
@@ -8,6 +8,7 @@ use firnflow_core::{CoreMetrics, NamespaceManager, NamespaceService};
 
 use crate::auth::{AuthConfig, AuthState};
 use crate::config::AppConfig;
+use crate::operations::OperationRegistry;
 use crate::rate_limit::RateLimitSettings;
 
 /// Shared state every handler receives via `axum::extract::State`.
@@ -28,6 +29,10 @@ pub struct AppState {
     /// Shared metrics registry; the `/metrics` handler encodes
     /// this into the Prometheus text format.
     pub metrics: Arc<CoreMetrics>,
+    /// Registry of in-flight and recently-finished background
+    /// operations (index builds, compaction, warmup). Backs the
+    /// `GET /operations/{id}` status endpoint.
+    pub operations: Arc<OperationRegistry>,
     /// Auth + rate-limit configuration. `Arc` so middleware closures
     /// can share it without cloning the inner `Secret`s. Tests
     /// construct `AuthConfig::disabled()` (default-open) via
@@ -104,10 +109,13 @@ pub async fn build_state(cfg: &AppConfig) -> anyhow::Result<AppState> {
         Arc::clone(&metrics),
     ));
 
+    let operations = Arc::new(OperationRegistry::new());
+
     Ok(AppState {
         service,
         manager,
         metrics,
+        operations,
         auth: Arc::new(auth),
         rate_limit: cfg.rate_limit.clone(),
         max_body_bytes: cfg.max_body_bytes,

--- a/crates/firnflow-api/tests/api_compact.rs
+++ b/crates/firnflow-api/tests/api_compact.rs
@@ -151,7 +151,13 @@ async fn compact_reduces_fragments_after_many_upserts() {
     );
     let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let compact_body: Value = serde_json::from_slice(&bytes).unwrap();
-    assert_eq!(compact_body["status"], "compaction queued");
+    assert!(
+        compact_body["operation_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("op_")),
+        "202 should carry an operation id: {compact_body}"
+    );
+    assert_eq!(compact_body["status"], "running");
 
     // 4. Wait for the background task to complete.
     let count = wait_for_compaction(&metrics, &ns, 1, Duration::from_secs(60)).await;

--- a/crates/firnflow-api/tests/api_index.rs
+++ b/crates/firnflow-api/tests/api_index.rs
@@ -129,7 +129,13 @@ async fn index_build_returns_202_and_records_metric() {
         StatusCode::ACCEPTED,
         "index endpoint must return 202"
     );
-    assert_eq!(body["status"], "index build queued");
+    assert!(
+        body["operation_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("op_")),
+        "202 should carry an operation id: {body}"
+    );
+    assert_eq!(body["status"], "running");
 
     // 3. Wait for the background task to complete by polling the
     //    index_build_duration histogram count.

--- a/crates/firnflow-api/tests/api_index_num_bits.rs
+++ b/crates/firnflow-api/tests/api_index_num_bits.rs
@@ -165,7 +165,13 @@ async fn index_build_with_num_bits_four_returns_202_and_completes() {
     });
     let (status, body) = post_json(app.clone(), format!("/ns/{ns}/index"), index_body).await;
     assert_eq!(status, StatusCode::ACCEPTED);
-    assert_eq!(body["status"], "index build queued");
+    assert!(
+        body["operation_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("op_")),
+        "202 should carry an operation id: {body}"
+    );
+    assert_eq!(body["status"], "running");
 
     let count = wait_for_index_build(&metrics, &ns, 1, Duration::from_secs(60)).await;
     assert_eq!(count, 1, "4-bit index build must complete");

--- a/crates/firnflow-api/tests/api_operations.rs
+++ b/crates/firnflow-api/tests/api_operations.rs
@@ -1,0 +1,137 @@
+//! Integration test for background-operation tracking (issue #34).
+//!
+//! Exercises the `GET /operations/{operation_id}` status endpoint: a
+//! scalar-index build returns an operation handle in its 202, which we
+//! poll to a terminal state, and an unknown id returns 404. Polling the
+//! operation status is the pattern that replaces inferring completion
+//! from a Prometheus histogram.
+
+use std::time::Duration;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use firnflow_api::router;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+mod common;
+use common::{test_state, test_state_offline, unique_namespace};
+
+async fn post_json(app: axum::Router, uri: String, body: Value) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    response_json(app.oneshot(request).await.unwrap()).await
+}
+
+async fn post_empty(app: axum::Router, uri: String) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    response_json(app.oneshot(request).await.unwrap()).await
+}
+
+async fn get(app: axum::Router, uri: String) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    response_json(app.oneshot(request).await.unwrap()).await
+}
+
+async fn response_json(response: axum::response::Response) -> (StatusCode, Value) {
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap()
+    };
+    (status, json)
+}
+
+/// Poll `GET /operations/{id}` until it reaches a terminal state or the
+/// deadline passes; returns the final record.
+async fn poll_operation(app: &axum::Router, op_id: &str, timeout: Duration) -> Value {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let (status, body) = get(app.clone(), format!("/operations/{op_id}")).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "operation should be retrievable: {body}"
+        );
+        if matches!(body["status"].as_str(), Some("succeeded") | Some("failed")) {
+            return body;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "operation {op_id} did not reach a terminal state in time: {body}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn scalar_index_operation_reaches_succeeded() {
+    let (state, _tmp) = test_state().await;
+    let app = router(state);
+    let ns = unique_namespace("op-scalar");
+
+    // Seed a row so the namespace and its `_ingested_at` column exist.
+    let (status, _) = post_json(
+        app.clone(),
+        format!("/ns/{ns}/upsert"),
+        json!({"rows": [{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0]}]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Kick off the scalar index build and capture the operation handle.
+    let (status, accepted) = post_empty(app.clone(), format!("/ns/{ns}/scalar-index")).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(accepted["kind"], "scalar_index");
+    assert_eq!(accepted["namespace"], ns);
+    assert_eq!(accepted["status"], "running");
+    let op_id = accepted["operation_id"]
+        .as_str()
+        .expect("202 carries an operation id")
+        .to_string();
+    assert!(op_id.starts_with("op_"));
+
+    // Poll the operation to a terminal state; the build should succeed.
+    let record = poll_operation(&app, &op_id, Duration::from_secs(60)).await;
+    assert_eq!(record["status"], "succeeded", "record: {record}");
+    assert_eq!(record["kind"], "scalar_index");
+    assert_eq!(record["namespace"], ns);
+    assert!(
+        record["finished_at_ms"].as_u64().is_some(),
+        "a finished timestamp is set on completion: {record}"
+    );
+    assert!(record["error"].is_null(), "no error on success: {record}");
+}
+
+/// No MinIO needed: the registry is in-memory, so an unknown id is a
+/// pure 404. Runs in CI to cover the endpoint wiring and the mapping.
+#[tokio::test]
+async fn unknown_operation_is_404() {
+    let (state, _tmp) = test_state_offline().await;
+    let app = router(state);
+
+    let (status, body) = get(app, "/operations/op_does-not-exist".to_string()).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not found"),
+        "expected a not-found message, got {body}"
+    );
+}

--- a/crates/firnflow-api/tests/api_scalar_index.rs
+++ b/crates/firnflow-api/tests/api_scalar_index.rs
@@ -202,7 +202,13 @@ async fn scalar_index_build_returns_202_and_list_still_works() {
         StatusCode::ACCEPTED,
         "scalar-index endpoint must return 202"
     );
-    assert_eq!(body["status"], "scalar index build queued");
+    assert!(
+        body["operation_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("op_")),
+        "202 should carry an operation id: {body}"
+    );
+    assert_eq!(body["status"], "running");
 
     // 2. Wait for the background task to complete.
     let count =
@@ -272,7 +278,13 @@ async fn scalar_index_on_empty_namespace_does_not_panic() {
 
     let (status, body) = post_empty(app.clone(), format!("/ns/{ns}/scalar-index")).await;
     assert_eq!(status, StatusCode::ACCEPTED);
-    assert_eq!(body["status"], "scalar index build queued");
+    assert!(
+        body["operation_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("op_")),
+        "202 should carry an operation id: {body}"
+    );
+    assert_eq!(body["status"], "running");
 
     // The build will have failed inside the background task. Confirm
     // the histogram for this namespace does *not* tick, then upsert

--- a/crates/firnflow-api/tests/common/mod.rs
+++ b/crates/firnflow-api/tests/common/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use firnflow_api::auth::{AuthConfig, Secret};
 use firnflow_api::config::AppConfig;
+use firnflow_api::operations::OperationRegistry;
 use firnflow_api::rate_limit::RateLimitSettings;
 use firnflow_api::AppState;
 use firnflow_core::cache::NamespaceCache;
@@ -97,6 +98,7 @@ pub async fn test_state_with_auth(
         service,
         manager,
         metrics,
+        operations: Arc::new(OperationRegistry::new()),
         auth: Arc::new(auth),
         rate_limit,
         max_body_bytes: 32 * 1024 * 1024,
@@ -157,6 +159,7 @@ pub async fn test_state_offline_with_auth(
         service,
         manager,
         metrics,
+        operations: Arc::new(OperationRegistry::new()),
         auth: Arc::new(auth),
         rate_limit,
         max_body_bytes: 32 * 1024 * 1024,

--- a/docs/api.html
+++ b/docs/api.html
@@ -51,7 +51,7 @@
     <h2>Authentication</h2>
     <p>When <code>FIRNFLOW_API_KEY</code> is configured, every protected endpoint requires <code>Authorization: Bearer &lt;token&gt;</code>. Two tiers exist:</p>
     <ul>
-      <li><strong>Read/write</strong> (<code>FIRNFLOW_API_KEY</code>) — <code>upsert</code>, <code>query</code>, <code>list</code>, <code>warmup</code>.</li>
+      <li><strong>Read/write</strong> (<code>FIRNFLOW_API_KEY</code>) — <code>upsert</code>, <code>query</code>, <code>list</code>, <code>warmup</code>, <code>GET /ns/{namespace}</code>, and <code>GET /operations/{id}</code>.</li>
       <li><strong>Admin</strong> (<code>FIRNFLOW_ADMIN_API_KEY</code>) — <code>delete</code>, <code>index</code>, <code>fts-index</code>, <code>scalar-index</code>, <code>compact</code>. The admin key also satisfies read/write routes. If no admin key is configured, the read/write key authorises admin routes too (single-key fallback).</li>
     </ul>
     <p><code>/health</code> is always public. <code>/metrics</code> is public unless <code>FIRNFLOW_METRICS_TOKEN</code> is set, in which case the same Bearer header is required. Token comparisons are constant-time (<code>subtle::ConstantTimeEq</code>). See <a href="configuration.html#authentication">configuration</a> for the full env-var list, including the optional <code>FIRNFLOW_RATE_LIMIT_RPS</code> / <code>FIRNFLOW_PREAUTH_IP_LIMIT_RPS</code> rate-limit knobs.</p>
@@ -424,6 +424,10 @@
         <table>
           <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
           <tbody>
+            <tr><td><code>operation_id</code></td><td>string</td><td>Opaque handle; poll <code>GET /operations/{operation_id}</code></td></tr>
+            <tr><td><code>kind</code></td><td>string</td><td><code>warmup</code></td></tr>
+            <tr><td><code>namespace</code></td><td>string</td><td>Namespace the work targets</td></tr>
+            <tr><td><code>status</code></td><td>string</td><td>Lifecycle state at acceptance (<code>running</code>)</td></tr>
             <tr><td><code>queued</code></td><td>integer</td><td>Number of queries submitted for background execution</td></tr>
           </tbody>
         </table>
@@ -437,7 +441,13 @@
       {"vector": [0.0, 1.0, 0.0, 0.0], "k": 5}
     ]
   }'</code></pre>
-        <pre><code>{"queued": 2}</code></pre>
+        <pre><code>{
+  "operation_id": "op_018f3a2b-7c4d-7e1f-9abc-1234567890ab",
+  "kind": "warmup",
+  "namespace": "demo",
+  "status": "running",
+  "queued": 2
+}</code></pre>
 
         <div class="callout callout-info">
           <div class="callout-title">Monitoring warmup progress</div>
@@ -468,7 +478,12 @@
         </table>
 
         <h4>Response (202)</h4>
-        <pre><code>{"status": "index build queued"}</code></pre>
+        <pre><code>{
+  "operation_id": "op_018f3a2b-7c4d-7e1f-9abc-1234567890ab",
+  "kind": "index",
+  "namespace": "demo",
+  "status": "running"
+}</code></pre>
 
         <h4>Example</h4>
         <pre><code>curl -X POST http://localhost:3000/ns/demo/index \
@@ -496,7 +511,12 @@
         <p>No request body required.</p>
 
         <h4>Response (202)</h4>
-        <pre><code>{"status": "fts index build queued"}</code></pre>
+        <pre><code>{
+  "operation_id": "op_018f3a2b-7c4d-7e1f-9abc-1234567890ab",
+  "kind": "fts_index",
+  "namespace": "demo",
+  "status": "running"
+}</code></pre>
 
         <h4>Example</h4>
         <pre><code>curl -X POST http://localhost:3000/ns/demo/fts-index</code></pre>
@@ -522,7 +542,12 @@
         <p>No request body required. v1 hardcodes the column to <code>_ingested_at</code> — the same constraint <code>/list</code> puts on <code>order_by</code>.</p>
 
         <h4>Response (202)</h4>
-        <pre><code>{"status": "scalar index build queued"}</code></pre>
+        <pre><code>{
+  "operation_id": "op_018f3a2b-7c4d-7e1f-9abc-1234567890ab",
+  "kind": "scalar_index",
+  "namespace": "demo",
+  "status": "running"
+}</code></pre>
 
         <h4>Example</h4>
         <pre><code>curl -X POST http://localhost:3000/ns/demo/scalar-index</code></pre>
@@ -548,7 +573,12 @@
         <p>No request body required.</p>
 
         <h4>Response (202)</h4>
-        <pre><code>{"status": "compaction queued"}</code></pre>
+        <pre><code>{
+  "operation_id": "op_018f3a2b-7c4d-7e1f-9abc-1234567890ab",
+  "kind": "compact",
+  "namespace": "demo",
+  "status": "running"
+}</code></pre>
 
         <h4>Example</h4>
         <pre><code>curl -X POST http://localhost:3000/ns/demo/compact</code></pre>
@@ -557,6 +587,54 @@
           <div class="callout-title">When to compact</div>
           Compact after many small upsert batches have created fragment sprawl. The server logs <code>fragments_removed</code> and <code>fragments_added</code> when the compaction completes.
         </div>
+      </div>
+    </div>
+
+    <!-- GET /operations/{operation_id} -->
+    <div class="endpoint">
+      <div class="endpoint-header" aria-expanded="true">
+        <span class="method method-get">GET</span>
+        <span class="endpoint-path">/operations/{operation_id}</span>
+        <span class="endpoint-desc">Background operation status</span>
+      </div>
+      <div class="endpoint-body">
+        <p>Returns the current state of background work started by an async endpoint (<code>warmup</code>, <code>index</code>, <code>fts-index</code>, <code>scalar-index</code>, <code>compact</code>). Each of those returns an <code>operation_id</code> in its <code>202</code>; poll this endpoint to wait for completion instead of inferring it from metrics.</p>
+        <p>Records are kept in memory and bounded: the most recent completed operations are retained and running operations are never evicted, so an unknown or long-since-completed id returns 404.</p>
+
+        <h4>Response (200)</h4>
+        <table>
+          <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>operation_id</code></td><td>string</td><td>The opaque id you polled</td></tr>
+            <tr><td><code>kind</code></td><td>string</td><td><code>warmup</code>, <code>index</code>, <code>fts_index</code>, <code>scalar_index</code>, or <code>compact</code></td></tr>
+            <tr><td><code>namespace</code></td><td>string</td><td>Namespace the work targets</td></tr>
+            <tr><td><code>status</code></td><td>string</td><td><code>running</code>, <code>succeeded</code>, or <code>failed</code></td></tr>
+            <tr><td><code>started_at_ms</code></td><td>integer</td><td>Milliseconds since the Unix epoch when work began</td></tr>
+            <tr><td><code>finished_at_ms</code></td><td>integer?</td><td>Completion time in epoch milliseconds; <code>null</code> while running</td></tr>
+            <tr><td><code>error</code></td><td>string?</td><td>Concise failure message; <code>null</code> unless <code>failed</code></td></tr>
+          </tbody>
+        </table>
+
+        <h4>Status codes</h4>
+        <table>
+          <thead><tr><th>Code</th><th>When</th></tr></thead>
+          <tbody>
+            <tr><td>200</td><td>Operation found</td></tr>
+            <tr><td>404</td><td>Unknown id, or its record has aged out of the bounded registry</td></tr>
+          </tbody>
+        </table>
+
+        <h4>Example</h4>
+        <pre><code>curl http://localhost:3000/operations/op_018f3a2b-7c4d-7e1f-9abc-1234567890ab</code></pre>
+        <pre><code>{
+  "operation_id": "op_018f3a2b-7c4d-7e1f-9abc-1234567890ab",
+  "kind": "scalar_index",
+  "namespace": "demo",
+  "status": "succeeded",
+  "started_at_ms": 1779580800123,
+  "finished_at_ms": 1779580802456,
+  "error": null
+}</code></pre>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

The async endpoints (warmup, index, fts-index, scalar-index, compact) accepted work, returned 202, and ran it fire-and-forget, so a caller had no way to ask whether a specific request was still running, succeeded, or failed short of reading the logs or watching a duration histogram. This adds a pollable handle: each of those endpoints now returns an opaque `operation_id` in its 202, and a new `GET /operations/{operation_id}` returns the current state (kind, namespace, status, start and finish timestamps, and a concise error message on failure).

The registry behind it is in-memory and bounded: the most recent completed operations are retained, running ones are never evicted, and an unknown or aged-out id returns 404. The lifecycle is intentionally small (running, then succeeded or failed); there is no queued, because the spawn model has no real queue, and no cancelled, because there is no cancellation API, and both can be added later without a breaking change. The store is process-local and does not survive a restart, which is also why the `owner_node` and `attempt` fields sketched in the issue's cluster-mode notes are left out for now.

## Behavior notes

The 202 bodies change shape from `{"status": "... queued"}` to `{operation_id, kind, namespace, status}`; warmup keeps its `queued` count alongside. The existing build and compaction duration metrics are unchanged.

Warmup attempts every query regardless of individual failures, but reports `failed` (with a count and the first error) if any query failed, so a poller does not read `succeeded` when nothing was actually warmed.

Operation error messages follow the same policy as the synchronous API errors: validation and capability messages are surfaced, while backend, cache, and I/O failures collapse to a generic `operation failed` with the full detail kept in the logs, so storage and provider internals do not leak through the operation record.

The status endpoint sits in the read/write tier; the opaque id returned in the 202 is the capability. `README.md` and `docs/api.html` are updated to match (endpoint table, the read/write tier overview, and a per-endpoint reference with the new 202 examples).

## Tests

~~~text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -j 1 -- -D warnings
cargo test -p firnflow-api --lib -j 1                          # 34 passed (registry + error-sanitiser unit tests)

# against local MinIO (127.0.0.1:9000), 2026-06-10:
cargo test -p firnflow-api --test api_operations     -j 1 -- --include-ignored   # 2 passed
cargo test -p firnflow-api --test api_warmup         -j 1 -- --ignored           # 1 passed
cargo test -p firnflow-api --test api_scalar_index   -j 1 -- --ignored           # 2 passed
cargo test -p firnflow-api --test api_index          -j 1 -- --ignored           # 1 passed
cargo test -p firnflow-api --test api_index_num_bits -j 1 -- --ignored           # 1 passed
cargo test -p firnflow-api --test api_compact        -j 1 -- --ignored           # 1 passed
~~~

`cargo test --workspace` was deliberately skipped on this branch (disk and memory pressure on the dev host); the change is confined to `firnflow-api` and was validated per-crate. The `firnflow-core` suite was not re-run because this branch makes no core changes.

Closes #34.
