### PR TITLE
Add the firn Python package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUST_BACKTRACE: short
+  # Strip debug info from CI builds. It is the dominant contributor to
+  # target/ size for the lance + datafusion + arrow graph, and with a
+  # fourth workspace member (the python cdylib) linking that graph the
+  # runner's ~14 GB margin no longer holds. Backtraces are already set
+  # to "short", so there is nothing to lose here.
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
   # Tests fall back to these defaults when the env vars are not set,
   # matching docker-compose.yml for local parity. Setting them
   # explicitly in CI makes the wiring visible at a glance.
@@ -37,7 +44,10 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: false
+          # The Rust toolchain is installed fresh below via dtolnay, so
+          # the preinstalled language tool-cache is dead weight here.
+          # Reclaiming it buys ~8 GB.
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,122 @@
+# Build and publish the `firn` Python package (crate at python/) to PyPI.
+#
+# Triggers on its own tag scheme, firn-v* (e.g. firn-v0.1.0), kept
+# separate from the server's v* tags so the package releases on its own
+# cadence and a server release never tries to re-push the same firn
+# version (PyPI rejects duplicate versions).
+#
+# Flow: build the wheel matrix + sdist -> publish to TestPyPI
+# automatically -> publish to PyPI behind a GitHub Environment approval
+# gate. Authentication is PyPI Trusted Publishing (OIDC); no token is
+# stored in the repo.
+name: pypi-publish
+
+on:
+  push:
+    tags:
+      - "firn-v*"
+
+# Default: read-only (lets the build/sdist jobs check out). The publish
+# jobs override this with `id-token: write` for OIDC trusted publishing.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build (${{ matrix.platform.os }} ${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Windows is intentionally omitted for v0.1: embedded local mode
+        # builds a Unix-shaped `file://` URI that is not valid on Windows
+        # (drive letters / backslashes), and it can't be tested from the
+        # build host. Linux + macOS cover the large majority of installs.
+        platform:
+          - { os: ubuntu-latest, target: x86_64, manylinux: "2_28" }
+          - { os: ubuntu-latest, target: aarch64, manylinux: "2_28" }
+          - { os: macos-latest, target: universal2-apple-darwin }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      # abi3-py310 means one wheel per platform serves every Python >= 3.10.
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          args: --release --strip --out dist -m python/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.os }}-${{ matrix.platform.target }}
+          path: dist
+
+  sdist:
+    name: build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist -m python/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+  smoke:
+    name: smoke-test the linux wheel
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-ubuntu-latest-x86_64
+          path: dist
+      - name: Install the built wheel and pytest
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install --no-index --find-links dist firn
+      - name: Run the suite against the installed wheel
+        run: pytest python/tests -q
+
+  testpypi:
+    name: publish to TestPyPI
+    needs: [build, sdist, smoke]
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write # OIDC for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  pypi:
+    name: publish to PyPI
+    needs: [testpypi]
+    runs-on: ubuntu-latest
+    # The `pypi` environment carries the required-reviewer rule, so this
+    # job waits for a manual approval in the Actions UI before it runs.
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 .DS_Store
 .env
 .env.local
+
+# Python examples: local virtualenv, demo data, byte-code caches
+/examples/.venv
+/examples/firn_data_demo
+__pycache__/
+*.pyc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "firnflow-python"
+version = "0.1.0"
+dependencies = [
+ "firnflow-core",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,6 +3693,15 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -5648,6 +5666,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "pyo3"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+dependencies = [
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6906,6 +6986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7338,6 +7424,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/firnflow-core",
     "crates/firnflow-api",
     "crates/firnflow-bench",
+    "python",
 ]
 
 [workspace.package]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,6 +7,10 @@
 #
 # Also installs protobuf-compiler because `lance-encoding` (pulled in
 # transitively by `lancedb`) has a build.rs that shells out to `protoc`.
+#
+# Python3 + maturin are here for the `firn` PyO3 bindings crate
+# (`python/`): pyo3's build script probes for a Python interpreter, and
+# maturin builds the importable extension / wheel.
 
 FROM rust:1.94-bookworm
 
@@ -14,6 +18,13 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         protobuf-compiler \
         libprotobuf-dev \
+        python3 \
+        python3-pip \
+        python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rustup component add rustfmt clippy
+
+# maturin builds the `firn` wheel from the PyO3 crate. pip's PEP 668
+# guard is bypassed because this is a throwaway dev image.
+RUN pip3 install --no-cache-dir --break-system-packages 'maturin>=1.7,<2'

--- a/crates/firnflow-api/src/config.rs
+++ b/crates/firnflow-api/src/config.rs
@@ -297,6 +297,9 @@ fn build_storage_options_for(scheme: Scheme) -> HashMap<String, String> {
     match scheme {
         Scheme::S3 => build_s3_storage_options(),
         Scheme::Gcs => build_gcs_storage_options(),
+        // Local filesystem mode needs no credentials or endpoint
+        // options; the directory is carried in the storage root.
+        Scheme::Local => HashMap::new(),
     }
 }
 

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -54,6 +54,7 @@ use lancedb::table::OptimizeAction;
 use lancedb::DistanceType;
 use object_store::aws::AmazonS3Builder;
 use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::local::LocalFileSystem;
 use object_store::path::Path as ObjectStorePath;
 use object_store::ObjectStore;
 use xxhash_rust::xxh3::xxh3_64;
@@ -631,7 +632,27 @@ impl NamespaceManager {
         match self.storage_root.scheme() {
             Scheme::S3 => self.build_s3_object_store(),
             Scheme::Gcs => self.build_gcs_object_store(),
+            Scheme::Local => self.build_local_object_store(),
         }
+    }
+
+    /// Build a local-filesystem `object_store` client rooted at the
+    /// configured base directory (embedded mode). Used by the namespace
+    /// delete path, which lists and removes objects under the namespace
+    /// prefix; the read/write path opens local Lance tables directly
+    /// through `lancedb::connect` with the `file://` URI.
+    ///
+    /// The base directory is created if absent so that
+    /// `LocalFileSystem::new_with_prefix` — which canonicalises the
+    /// prefix and requires it to exist — succeeds even before any
+    /// namespace has been written.
+    fn build_local_object_store(&self) -> Result<Arc<dyn ObjectStore>, FirnflowError> {
+        let dir = self.storage_root.bucket();
+        std::fs::create_dir_all(dir)
+            .map_err(|e| FirnflowError::Backend(format!("create local storage dir {dir}: {e}")))?;
+        let store = LocalFileSystem::new_with_prefix(dir)
+            .map_err(|e| FirnflowError::Backend(format!("build local object store: {e}")))?;
+        Ok(Arc::new(store))
     }
 
     fn build_s3_object_store(&self) -> Result<Arc<dyn ObjectStore>, FirnflowError> {

--- a/crates/firnflow-core/src/storage_root.rs
+++ b/crates/firnflow-core/src/storage_root.rs
@@ -1,14 +1,16 @@
 //! Backend-agnostic storage root.
 //!
 //! A [`StorageRoot`] captures the parsed shape of a Firn deployment's
-//! object-storage URI: which scheme (`s3`, `gs`), which bucket, and
-//! optionally a fixed prefix that every namespace lives under. The
+//! object-storage URI: which scheme (`s3`, `gs`, or `file`), which
+//! bucket (or local directory, for `file`), and optionally a fixed
+//! prefix that every namespace lives under. The
 //! type is the single hand-off between operator config (the
 //! `FIRNFLOW_STORAGE_URI` / `FIRNFLOW_S3_BUCKET` env vars) and the
 //! parts of `firnflow-core` that need to construct namespace URIs and
 //! `object_store` clients.
 //!
-//! Both `s3://` and `gs://` are routable schemes. The actual
+//! `s3://`, `gs://`, and `file://` (a local filesystem directory, for
+//! embedded mode) are routable schemes. The actual
 //! `object_store` client and lancedb backend are picked by
 //! [`Scheme`] downstream — see `NamespaceManager::build_object_store`
 //! for the dispatch. GCS routing uses the native
@@ -20,6 +22,8 @@
 //! prefixes are stored as `None`, never as `Some("")`. This makes
 //! equality of two parsed roots a meaningful "operator pointed both
 //! env vars at the same place" check.
+
+use std::path::{Path, PathBuf};
 
 use crate::error::FirnflowError;
 use crate::namespace::NamespaceId;
@@ -44,6 +48,13 @@ pub enum Scheme {
     /// drops into `object_store::gcp::GoogleCloudStorage` keyed off
     /// the same credentials.
     Gcs,
+    /// Local filesystem directory, for embedded mode (no network, no
+    /// credentials). The `bucket` field of a [`StorageRoot`] with this
+    /// scheme holds the absolute base directory; each namespace is a
+    /// subdirectory beneath it that `lancedb::connect` opens as a local
+    /// Lance table via a `file://` URI, and the delete path lists and
+    /// removes objects through `object_store::local::LocalFileSystem`.
+    Local,
 }
 
 impl Scheme {
@@ -53,6 +64,7 @@ impl Scheme {
         match self {
             Scheme::S3 => "s3",
             Scheme::Gcs => "gs",
+            Scheme::Local => "file",
         }
     }
 }
@@ -75,14 +87,18 @@ pub struct StorageRoot {
 
 impl StorageRoot {
     /// Parse a URI of the form `scheme://bucket[/prefix...]`.
-    /// Supported schemes are `s3` (any S3-compatible backend) and
-    /// `gs` (native Google Cloud Storage).
+    /// Supported schemes are `s3` (any S3-compatible backend),
+    /// `gs` (native Google Cloud Storage), and `file` (a local
+    /// filesystem directory for embedded mode, e.g.
+    /// `file:///srv/firn_data`; the path is resolved to an absolute
+    /// directory via [`StorageRoot::local`]).
     ///
     /// # Errors
     ///
     /// - `InvalidRequest` if the URI is empty, missing the `://`
     ///   separator, or has an empty bucket segment.
-    /// - `InvalidRequest` if the scheme is neither `s3` nor `gs`.
+    /// - `InvalidRequest` if the scheme is not one of `s3`, `gs`,
+    ///   `file`.
     pub fn parse(uri: &str) -> Result<Self, FirnflowError> {
         let uri = uri.trim();
         if uri.is_empty() {
@@ -99,10 +115,14 @@ impl StorageRoot {
         let scheme = match scheme_part {
             "s3" => Scheme::S3,
             "gs" => Scheme::Gcs,
+            // Local filesystem: the remainder is a directory path, not a
+            // `bucket/prefix` pair, so route straight to `local` and skip
+            // the bucket/prefix split below.
+            "file" => return Self::local(rest),
             other => {
                 return Err(FirnflowError::InvalidRequest(format!(
                     "storage URI {uri:?} uses unrecognised scheme {other:?}; \
-                     supported schemes are s3, gs"
+                     supported schemes are s3, gs, file"
                 )));
             }
         };
@@ -146,6 +166,37 @@ impl StorageRoot {
         Ok(StorageRoot {
             scheme: Scheme::S3,
             bucket: trimmed.to_string(),
+            prefix: None,
+        })
+    }
+
+    /// Construct a local-filesystem storage root from a directory
+    /// path, for embedded mode.
+    ///
+    /// The path is resolved to an absolute path (relative paths are
+    /// joined onto the current working directory) so that the
+    /// `file://` URI handed to `lancedb::connect` and the local
+    /// `object_store` client agree regardless of the process's working
+    /// directory. The directory need not exist yet — embedded
+    /// namespace state is lazy until the first write. The resulting
+    /// `bucket` field holds the absolute directory and `prefix` is
+    /// always `None`.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidRequest` if the path is empty or not valid UTF-8.
+    /// - `Io` if the current working directory cannot be read while
+    ///   resolving a relative path.
+    pub fn local(dir: impl Into<PathBuf>) -> Result<Self, FirnflowError> {
+        let dir = dir.into();
+        if dir.as_os_str().is_empty() {
+            return Err(FirnflowError::InvalidRequest(
+                "local storage directory must not be empty".into(),
+            ));
+        }
+        Ok(StorageRoot {
+            scheme: Scheme::Local,
+            bucket: absolute_utf8_dir(&dir)?,
             prefix: None,
         })
     }
@@ -223,6 +274,31 @@ impl std::fmt::Display for StorageRoot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.as_uri())
     }
+}
+
+/// Resolve a directory path to an absolute, UTF-8 string without
+/// requiring it to exist on disk. Relative paths are joined onto the
+/// current working directory; the path is deliberately *not* run
+/// through `fs::canonicalize` (which requires the path to exist) so a
+/// not-yet-created `./firn_data` resolves cleanly — embedded namespace
+/// state is lazy until the first write. Trailing slashes are trimmed
+/// so `./firn_data` and `./firn_data/` produce equal roots, mirroring
+/// the trailing-slash canonicalisation the cloud parser applies.
+fn absolute_utf8_dir(dir: &Path) -> Result<String, FirnflowError> {
+    let abs: PathBuf = if dir.is_absolute() {
+        dir.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(dir)
+    };
+    let s = abs.to_str().ok_or_else(|| {
+        FirnflowError::InvalidRequest(format!("local storage path {abs:?} is not valid UTF-8"))
+    })?;
+    let trimmed = s.trim_end_matches('/');
+    Ok(if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    })
 }
 
 #[cfg(test)]
@@ -316,7 +392,7 @@ mod tests {
     fn parse_rejects_unknown_scheme() {
         let err = StorageRoot::parse("ftp://my-bucket").unwrap_err();
         assert!(matches!(err, FirnflowError::InvalidRequest(_)));
-        let err = StorageRoot::parse("file:///tmp/foo").unwrap_err();
+        let err = StorageRoot::parse("http://my-bucket").unwrap_err();
         assert!(matches!(err, FirnflowError::InvalidRequest(_)));
     }
 
@@ -438,5 +514,75 @@ mod tests {
     fn display_matches_as_uri() {
         let root = StorageRoot::parse("s3://my-bucket/firn").unwrap();
         assert_eq!(format!("{root}"), root.as_uri());
+    }
+
+    #[test]
+    fn local_constructor_makes_relative_path_absolute() {
+        // A relative dir resolves against cwd; the dir need not exist.
+        let root = StorageRoot::local("firn_data").unwrap();
+        assert_eq!(root.scheme(), Scheme::Local);
+        assert!(
+            root.bucket().starts_with('/'),
+            "local bucket should be an absolute path, got {:?}",
+            root.bucket()
+        );
+        assert!(root.bucket().ends_with("/firn_data"));
+        assert_eq!(root.prefix(), None);
+    }
+
+    #[test]
+    fn local_keeps_absolute_path_as_is() {
+        let root = StorageRoot::local("/var/lib/firn").unwrap();
+        assert_eq!(root.bucket(), "/var/lib/firn");
+        assert_eq!(root.scheme(), Scheme::Local);
+    }
+
+    #[test]
+    fn local_trims_trailing_slash() {
+        let with = StorageRoot::local("/var/lib/firn/").unwrap();
+        let without = StorageRoot::local("/var/lib/firn").unwrap();
+        assert_eq!(with, without);
+        assert_eq!(with.bucket(), "/var/lib/firn");
+    }
+
+    #[test]
+    fn local_rejects_empty() {
+        assert!(matches!(
+            StorageRoot::local("").unwrap_err(),
+            FirnflowError::InvalidRequest(_)
+        ));
+    }
+
+    #[test]
+    fn parse_file_scheme_is_local_and_absolute() {
+        let root = StorageRoot::parse("file:///srv/firn_data").unwrap();
+        assert_eq!(root.scheme(), Scheme::Local);
+        assert_eq!(root.bucket(), "/srv/firn_data");
+        assert_eq!(root.prefix(), None);
+    }
+
+    #[test]
+    fn local_namespace_uri_is_a_file_url() {
+        let root = StorageRoot::local("/srv/firn_data").unwrap();
+        assert_eq!(
+            root.namespace_uri(&ns("docs")),
+            "file:///srv/firn_data/docs"
+        );
+    }
+
+    #[test]
+    fn local_namespace_object_path_is_relative() {
+        // The local object store is rooted at the base dir, so the
+        // per-namespace path is just the namespace name.
+        let root = StorageRoot::local("/srv/firn_data").unwrap();
+        assert_eq!(root.namespace_object_path(&ns("docs")), "docs");
+    }
+
+    #[test]
+    fn local_round_trips_through_parse() {
+        let root = StorageRoot::local("/srv/firn_data").unwrap();
+        let rendered = root.as_uri();
+        assert_eq!(rendered, "file:///srv/firn_data");
+        assert_eq!(StorageRoot::parse(&rendered).unwrap(), root);
     }
 }

--- a/crates/firnflow-core/tests/manager_local_fs.rs
+++ b/crates/firnflow-core/tests/manager_local_fs.rs
@@ -1,0 +1,144 @@
+//! Embedded-mode integration test: `NamespaceManager` against a local
+//! filesystem `StorageRoot` (no S3, no MinIO, no network).
+//!
+//! Proves the `Scheme::Local` path end-to-end: `lancedb::connect`
+//! opens a local Lance table from the `file://` URI, an upsert writes
+//! a directory tree under the base dir, a query reads it back, and the
+//! delete path drops through `object_store::local::LocalFileSystem` to
+//! remove the namespace's objects. Unlike the cloud manager tests this
+//! one is deliberately **not** `#[ignore]`d — embedded mode is exactly
+//! the zero-infrastructure case, so it runs in CI and locally as-is.
+
+use std::collections::HashMap;
+
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{NamespaceId, NamespaceManager, StorageRoot, UpsertRow};
+use tempfile::TempDir;
+
+const DIM: usize = 8;
+
+fn unit_vector(axis: usize) -> Vec<f32> {
+    let mut v = vec![0.0_f32; DIM];
+    v[axis] = 1.0;
+    v
+}
+
+fn local_manager(dir: &TempDir) -> NamespaceManager {
+    NamespaceManager::new(
+        StorageRoot::local(dir.path()).unwrap(),
+        HashMap::new(),
+        test_metrics(),
+    )
+}
+
+#[tokio::test]
+async fn local_fs_upsert_query_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let manager = local_manager(&dir);
+    let ns = NamespaceId::new("embedded-roundtrip").unwrap();
+
+    let rows: Vec<UpsertRow> = vec![
+        (1u64, unit_vector(0)).into(),
+        (2u64, unit_vector(1)).into(),
+        (3u64, unit_vector(2)).into(),
+    ];
+    manager.upsert(&ns, rows).await.expect("local upsert");
+
+    // The namespace directory must now exist on the local filesystem
+    // under the base dir — proof that lancedb opened and wrote to the
+    // `file://` root rather than silently failing or going elsewhere.
+    assert!(
+        dir.path().join("embedded-roundtrip").is_dir(),
+        "expected a local Lance table directory for the namespace"
+    );
+
+    let results = manager
+        .query(&ns, unit_vector(0), None, 3, None, None, true)
+        .await
+        .expect("local query");
+
+    assert_eq!(results.results.len(), 3, "should return top-3 hits");
+    let top = &results.results[0];
+    assert_eq!(top.id, 1, "nearest neighbour of axis-0 must be id=1");
+    assert!(
+        top.score < 0.01,
+        "self-distance should be ~0, got {}",
+        top.score
+    );
+    let top_vector = top
+        .vector
+        .as_ref()
+        .expect("default query must return the stored vector");
+    assert_eq!(top_vector.len(), DIM, "returned vector width must match");
+}
+
+#[tokio::test]
+async fn local_fs_fts_text_search() {
+    // The path the Python binding's text/hybrid search relies on:
+    // build a BM25 index over the text column, then run an FTS-only
+    // query. Rows carry a vector (firn is a vector engine) plus text.
+    let dir = TempDir::new().unwrap();
+    let manager = local_manager(&dir);
+    let ns = NamespaceId::new("embedded-fts").unwrap();
+
+    let rows: Vec<UpsertRow> = vec![
+        UpsertRow {
+            id: 1,
+            vector: unit_vector(0),
+            vectors: None,
+            text: Some("the quick brown fox".into()),
+        },
+        UpsertRow {
+            id: 2,
+            vector: unit_vector(1),
+            vectors: None,
+            text: Some("a lazy dog sleeps".into()),
+        },
+        UpsertRow {
+            id: 3,
+            vector: unit_vector(2),
+            vectors: None,
+            text: Some("the fox runs fast".into()),
+        },
+    ];
+    manager.upsert(&ns, rows).await.expect("local upsert");
+    manager
+        .create_fts_index(&ns)
+        .await
+        .expect("create fts index");
+
+    // FTS-only: empty vector, text set.
+    let results = manager
+        .query(&ns, Vec::new(), None, 10, None, Some("fox".into()), false)
+        .await
+        .expect("fts query");
+    let ids: Vec<u64> = results.results.iter().map(|r| r.id).collect();
+    assert!(
+        ids.contains(&1) && ids.contains(&3),
+        "'fox' should match rows 1 and 3, got {ids:?}"
+    );
+    assert!(
+        !ids.contains(&2),
+        "row 2 has no 'fox' and must not match, got {ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn local_fs_delete_removes_namespace_objects() {
+    let dir = TempDir::new().unwrap();
+    let manager = local_manager(&dir);
+    let ns = NamespaceId::new("embedded-delete").unwrap();
+
+    let rows: Vec<UpsertRow> = vec![(1u64, unit_vector(0)).into()];
+    manager.upsert(&ns, rows).await.expect("local upsert");
+    assert!(dir.path().join("embedded-delete").is_dir());
+
+    // Delete drops into the local object store, lists the namespace
+    // prefix, and removes each object. At least the manifest + data
+    // files should come back in the count.
+    let deleted = manager.delete(&ns).await.expect("local delete");
+    assert!(
+        deleted > 0,
+        "delete should remove at least one object, got {deleted}"
+    );
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# firn Python examples
+
+Runnable examples for the `firn` Python package (built from `../python`).
+
+## Setup
+
+```bash
+./setup.sh
+```
+
+Creates a virtualenv and installs `firn` (from the local wheel in
+`../target/wheels`) plus the dependencies the examples use (OpenCLIP on
+CPU torch, scikit-image, boto3).
+
+## quickstart — local, no infrastructure
+
+```bash
+./run.sh quickstart
+```
+
+Writes to `./firn_data_demo`, then runs vector, full-text (BM25), and
+hybrid search. No server, no credentials.
+
+## clip — image search on object storage
+
+```bash
+export TIGRIS_ACCESS_KEY=...
+export TIGRIS_SECRET_KEY=...
+export TIGRIS_BUCKET=firn-tigris-bucket   # optional; this is the default
+./run.sh clip
+```
+
+Embeds a few sample photos with OpenCLIP, stores the photo bytes as
+Tigris objects and the embeddings in firn (also on Tigris), then
+searches by text ("a cat") and by image. The first run downloads the
+CLIP weights (~350 MB, then cached); sample photos are bundled with
+scikit-image.

--- a/examples/clip_search.py
+++ b/examples/clip_search.py
@@ -1,0 +1,110 @@
+"""firn + OpenCLIP photo search on Tigris.
+
+Embeds a few sample photos with OpenCLIP, stores the image embeddings in
+firn (whose tables live on Tigris) and the photo bytes as Tigris objects,
+then searches by text and by image.
+
+CLIP puts images and text in the same vector space, so a text query like
+"a cat" finds the cat photo even though only image embeddings are stored.
+
+Credentials come from the environment (TIGRIS_ACCESS_KEY /
+TIGRIS_SECRET_KEY / TIGRIS_BUCKET).
+"""
+
+import io
+import os
+
+import boto3
+import firn
+import open_clip
+import torch
+from PIL import Image
+from skimage import data
+
+ENDPOINT = "https://t3.storage.dev"
+BUCKET = os.environ.get("TIGRIS_BUCKET", "firn-tigris-bucket")
+AK = os.environ["TIGRIS_ACCESS_KEY"]
+SK = os.environ["TIGRIS_SECRET_KEY"]
+PREFIX = "clip-demo/photos/"
+
+# A few labelled sample photos, bundled with scikit-image (no download).
+SAMPLES = {
+    "cat.jpg": data.chelsea(),
+    "coffee.jpg": data.coffee(),
+    "astronaut.jpg": data.astronaut(),
+    "rocket.jpg": data.rocket(),
+}
+
+# --- CLIP model (downloads the weights once, ~350 MB, then cached) ---
+# The "-quickgelu" variant matches the openai weights' activation, which
+# avoids a QuickGELU-mismatch warning.
+print("loading OpenCLIP ViT-B-32 ...")
+model, _, preprocess = open_clip.create_model_and_transforms(
+    "ViT-B-32-quickgelu", pretrained="openai"
+)
+tokenizer = open_clip.get_tokenizer("ViT-B-32-quickgelu")
+model.eval()
+
+
+def embed_image(img: Image.Image) -> list:
+    tensor = preprocess(img.convert("RGB")).unsqueeze(0)
+    with torch.no_grad():
+        feat = model.encode_image(tensor)
+        feat /= feat.norm(dim=-1, keepdim=True)  # unit-normalise
+    return feat[0].tolist()
+
+
+def embed_text(text: str) -> list:
+    with torch.no_grad():
+        feat = model.encode_text(tokenizer([text]))
+        feat /= feat.norm(dim=-1, keepdim=True)
+    return feat[0].tolist()
+
+
+# Tigris S3 client for the raw photo bytes.
+s3 = boto3.client(
+    "s3",
+    endpoint_url=ENDPOINT,
+    region_name="auto",
+    aws_access_key_id=AK,
+    aws_secret_access_key=SK,
+)
+
+# firn, with its search index living on Tigris too.
+db = firn.connect(
+    storage_url=f"s3://{BUCKET}/clip-demo",
+    endpoint=ENDPOINT,
+    region="auto",
+    access_key=AK,
+    secret_key=SK,
+)
+
+# --- ingest: photo bytes -> Tigris objects, embeddings -> firn ---
+images = {}
+docs = []
+for i, (name, arr) in enumerate(SAMPLES.items(), start=1):
+    img = Image.fromarray(arr).convert("RGB")
+    images[name] = img
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    buf.seek(0)
+    key = PREFIX + name
+    s3.upload_fileobj(buf, BUCKET, key)
+    docs.append({"id": i, "vector": embed_image(img), "text": key})
+db.add(docs)
+print(f"ingested {len(docs)} photos -> Tigris ({BUCKET}/{PREFIX}) + firn\n")
+
+# --- search by text (lower distance = closer match) ---
+print("text -> image search:")
+for q in ["a cat", "a cup of coffee", "an astronaut in space", "a rocket"]:
+    top = db.search(vector=embed_text(q), limit=1)[0]
+    print(f"  {q!r:28} -> {top.text}  (distance {top.score:.3f})")
+
+# --- search by image ---
+q_name = "cat.jpg"
+print(f"\nimage -> image search (query: {q_name}):")
+for h in db.search(vector=embed_image(images[q_name]), limit=3):
+    print(f"  {h.text}  (distance {h.score:.3f})")
+
+db.close()
+print("\nok")

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,35 @@
+"""firn quickstart: local, no infrastructure.
+
+Each row carries a vector (your embedding) plus optional text. Search by
+vector (nearest-neighbour), by text (BM25 full-text), or both at once
+(hybrid). The full-text index is built on the first text search.
+"""
+
+import firn
+
+# No server, no infrastructure: writes to ./firn_data_demo locally.
+db = firn.connect("./firn_data_demo")
+
+# Bring your own vectors. Tiny 4-dim toy vectors here, each with text.
+db.add(
+    [
+        {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "text": "the quick brown fox"},
+        {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0], "text": "a lazy dog sleeps"},
+        {"id": 3, "vector": [0.0, 0.0, 1.0, 0.0], "text": "the fox runs fast"},
+    ]
+)
+
+print("full-text search for 'fox':")
+for hit in db.search("fox"):
+    print(f"  id={hit.id}  score={hit.score:.4f}  text={hit.text!r}")
+
+print("\nvector search near [1, 0, 0, 0]:")
+for hit in db.search(vector=[1.0, 0.0, 0.0, 0.0], limit=2):
+    print(f"  id={hit.id}  score={hit.score:.4f}  text={hit.text!r}")
+
+print("\nhybrid (text + vector):")
+for hit in db.search("fox", vector=[1.0, 0.0, 0.0, 0.0], limit=3):
+    print(f"  id={hit.id}  score={hit.score:.4f}  text={hit.text!r}")
+
+db.close()
+print("\nok")

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,10 @@
+# Installed by setup.sh. torch + torchvision are the CPU builds, from a
+# separate index (and must come from the same index to match):
+#   pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+torch
+torchvision
+open_clip_torch
+scikit-image
+pillow
+boto3
+firn  # from the local wheel in ../target/wheels

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run one of the examples. Needs ./setup.sh first.
+#
+#   ./run.sh quickstart   # local, no credentials
+#   ./run.sh clip          # CLIP image search on Tigris (needs creds)
+set -Eeuo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${HERE}"
+[ -d .venv ] || {
+    echo "run ./setup.sh first" >&2
+    exit 1
+}
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+case "${1:-quickstart}" in
+quickstart)
+    python quickstart.py
+    ;;
+clip)
+    : "${TIGRIS_ACCESS_KEY:?set TIGRIS_ACCESS_KEY for the clip example}"
+    : "${TIGRIS_SECRET_KEY:?set TIGRIS_SECRET_KEY for the clip example}"
+    python clip_search.py
+    ;;
+*)
+    echo "unknown example '${1}'. Try: quickstart | clip" >&2
+    exit 1
+    ;;
+esac

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Create a virtualenv with the local firn wheel plus the dependencies the
+# examples use (OpenCLIP on CPU torch, scikit-image, boto3).
+set -Eeuo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WHEELS="${HERE}/../target/wheels"
+cd "${HERE}"
+
+if [ ! -d "${WHEELS}" ] || ! ls "${WHEELS}"/firn-*.whl >/dev/null 2>&1; then
+    echo "No firn wheel in ${WHEELS}. Build it first:" >&2
+    echo "  (cd .. && ./scripts/maturin build -m python/Cargo.toml -o target/wheels)" >&2
+    exit 1
+fi
+
+python3 -m venv .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+pip install --upgrade pip
+# CPU-only torch + torchvision, from the same index so their builds
+# match (a mismatched torchvision fails with "torchvision::nms does not
+# exist"). No CUDA, so the download stays a few hundred MB.
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+pip install open_clip_torch scikit-image pillow boto3
+pip install --force-reinstall --find-links "${WHEELS}" firn
+echo "setup complete — run an example:  ./run.sh quickstart   |   ./run.sh clip"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "firnflow-python"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+description = "PyO3 bindings exposing the firnflow engine as the `firn` Python package."
+
+[lib]
+name = "_native"
+crate-type = ["cdylib"]
+# No Rust test harness for this crate: the behaviour is covered by the
+# pytest suite (python/tests), and a `cargo test` harness for a
+# `cdylib` + `extension-module` crate needs to link libpython, which the
+# workspace-wide `cargo test` in CI must not depend on. Doctests are off
+# for the same reason.
+test = false
+doctest = false
+
+[dependencies]
+firnflow-core = { path = "../crates/firnflow-core" }
+pyo3 = { version = "0.25", features = ["abi3-py310", "extension-module"] }
+tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time", "net", "fs"] }

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,31 @@
+# firn
+
+Vector + full-text search on object storage, embeddable in-process. No
+server, no infrastructure to stand up.
+
+```python
+import firn
+
+db = firn.connect()                 # local ./firn_data
+# ...or object storage:
+# db = firn.connect(storage_url="s3://bucket",
+#                   access_key=..., secret_key=...)
+
+db.add([
+    {"id": 1, "vector": [0.1, 0.2, 0.3], "text": "the quick brown fox"},
+    {"id": 2, "vector": [0.4, 0.5, 0.6], "text": "a lazy dog sleeps"},
+])
+
+hits = db.search("fox")                            # full-text (BM25)
+hits = db.search(vector=[0.1, 0.2, 0.3])           # nearest-neighbour
+hits = db.search("fox", vector=[0.1, 0.2, 0.3])    # hybrid (fused)
+for hit in hits:
+    print(hit.id, hit.score, hit.text)
+```
+
+Each row carries a vector (your embedding) and optional text. Search by
+vector, by text, or both at once (reciprocal-rank fused). Storage is a
+local directory or any S3-compatible object store (AWS, Tigris, R2,
+MinIO, …) or GCS.
+
+Apache-2.0. Part of [Firn](https://firnflow.io).

--- a/python/firn/__init__.py
+++ b/python/firn/__init__.py
@@ -1,0 +1,36 @@
+"""firn: vector + full-text search on object storage, embedded in-process.
+
+No server, no infrastructure:
+
+    import firn
+
+    db = firn.connect()                 # writes to ./firn_data
+    db.add([{"id": 1, "vector": [0.1, 0.2, 0.3], "text": "hello world"}])
+    hits = db.search("hello")           # text, vector, or both (hybrid)
+"""
+
+from ._native import (
+    Client,
+    Collection,
+    FirnError,
+    Hit,
+    StorageError,
+    TenantError,
+    UnsupportedError,
+    ValidationError,
+    connect,
+)
+
+__all__ = [
+    "connect",
+    "Client",
+    "Collection",
+    "Hit",
+    "FirnError",
+    "StorageError",
+    "TenantError",
+    "ValidationError",
+    "UnsupportedError",
+]
+
+__version__ = "0.1.0"

--- a/python/firn/_native.pyi
+++ b/python/firn/_native.pyi
@@ -1,0 +1,73 @@
+"""Type stubs for the native firn extension module (`firn._native`)."""
+
+from typing import Optional
+
+class Hit:
+    """A single search hit."""
+
+    id: int
+    score: float
+    text: Optional[str]
+    vector: Optional[list[float]]
+    ingested_at_micros: Optional[int]
+    def __repr__(self) -> str: ...
+
+class Collection:
+    """A handle to one named collection."""
+
+    def add(self, documents: list[dict], *, tenant: Optional[str] = None) -> int: ...
+    def upsert(self, documents: list[dict], *, tenant: Optional[str] = None) -> int: ...
+    def delete(
+        self, ids: Optional[list[int]] = None, *, tenant: Optional[str] = None
+    ) -> int: ...
+    def search(
+        self,
+        query: Optional[str] = None,
+        *,
+        vector: Optional[list[float]] = None,
+        vectors: Optional[list[list[float]]] = None,
+        hybrid: bool = False,
+        limit: int = 10,
+        tenant: Optional[str] = None,
+        include_vectors: bool = False,
+    ) -> list[Hit]: ...
+
+class Client:
+    """An embedded firn client over a default collection."""
+
+    def collection(self, name: str) -> Collection: ...
+    def add(self, documents: list[dict], *, tenant: Optional[str] = None) -> int: ...
+    def upsert(self, documents: list[dict], *, tenant: Optional[str] = None) -> int: ...
+    def delete(
+        self, ids: Optional[list[int]] = None, *, tenant: Optional[str] = None
+    ) -> int: ...
+    def search(
+        self,
+        query: Optional[str] = None,
+        *,
+        vector: Optional[list[float]] = None,
+        vectors: Optional[list[list[float]]] = None,
+        hybrid: bool = False,
+        limit: int = 10,
+        tenant: Optional[str] = None,
+        include_vectors: bool = False,
+    ) -> list[Hit]: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> "Client": ...
+    def __exit__(self, *exc: object) -> bool: ...
+
+def connect(
+    path: Optional[str] = None,
+    *,
+    storage_url: Optional[str] = None,
+    access_key: Optional[str] = None,
+    secret_key: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Client: ...
+
+class FirnError(Exception): ...
+class StorageError(FirnError): ...
+class TenantError(FirnError): ...
+class ValidationError(FirnError): ...
+class UnsupportedError(FirnError): ...

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "firn"
+version = "0.1.0"
+description = "Multi-tenant hybrid (vector + full-text) search on object storage, embeddable in-process."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Gordon Murray" }]
+keywords = ["vector-search", "full-text-search", "hybrid-search", "object-storage", "embeddings"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Database :: Database Engines/Servers",
+    "Intended Audience :: Developers",
+]
+
+[project.urls]
+Homepage = "https://firnflow.io"
+Repository = "https://github.com/gordonmurray/firnflow"
+
+[tool.maturin]
+module-name = "firn._native"
+python-source = "."
+features = ["pyo3/extension-module"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,0 +1,866 @@
+//! PyO3 bindings exposing the firnflow engine as the `firn` Python
+//! package (the native `firn._native` module).
+//!
+//! `connect()` builds a [`NamespaceService`] over a local-filesystem or
+//! object-storage root with its own foyer result cache, and the
+//! `Client` / `Collection` data-plane methods map onto it. Every
+//! blocking engine call releases the GIL so other Python threads make
+//! progress.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+use firnflow_core::cache::NamespaceCache;
+use firnflow_core::{
+    CoreMetrics, FirnflowError, NamespaceId, NamespaceManager, NamespaceService, QueryRequest,
+    QueryResult, StorageRoot, UpsertRow,
+};
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use tokio::runtime::Runtime;
+
+/// Embedded result-cache sizes (RAM tier, NVMe tier). Modest defaults
+/// for a single-process user; the server runs larger.
+const CACHE_MEMORY_BYTES: usize = 16 * 1024 * 1024;
+const CACHE_NVME_BYTES: usize = 64 * 1024 * 1024;
+
+/// Collection used when a caller does not name one explicitly.
+const DEFAULT_COLLECTION: &str = "default";
+
+/// Process-global multi-threaded tokio runtime shared by all clients.
+///
+/// One runtime per process (not per `Client`) keeps thread counts
+/// bounded; Lance issues concurrent object-store requests, so a
+/// multi-thread scheduler is required rather than a current-thread one.
+fn runtime() -> &'static Runtime {
+    static RT: OnceLock<Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build the firn tokio runtime")
+    })
+}
+
+create_exception!(
+    _native,
+    FirnError,
+    PyException,
+    "Base class for all firn errors."
+);
+create_exception!(
+    _native,
+    StorageError,
+    FirnError,
+    "Object store, Lance, cache, or disk failure."
+);
+create_exception!(
+    _native,
+    TenantError,
+    FirnError,
+    "Invalid tenant or collection name."
+);
+create_exception!(
+    _native,
+    ValidationError,
+    FirnError,
+    "Invalid request payload or arguments."
+);
+create_exception!(
+    _native,
+    UnsupportedError,
+    FirnError,
+    "Feature not available in this build."
+);
+
+/// Map an engine error onto the Python exception hierarchy. The
+/// original engine message is preserved so the Python traceback is
+/// actionable.
+fn to_py_err(err: FirnflowError) -> PyErr {
+    let msg = err.to_string();
+    match err {
+        FirnflowError::Backend(_) | FirnflowError::Io(_) | FirnflowError::Cache(_) => {
+            StorageError::new_err(msg)
+        }
+        FirnflowError::InvalidNamespace(_) => TenantError::new_err(msg),
+        FirnflowError::InvalidRequest(_) => ValidationError::new_err(msg),
+        FirnflowError::Unsupported(_) => UnsupportedError::new_err(msg),
+        FirnflowError::Metrics(_) => FirnError::new_err(msg),
+    }
+}
+
+/// A single search hit, built from the engine's `QueryResult`.
+#[pyclass(frozen, get_all)]
+#[derive(Clone)]
+struct Hit {
+    /// Stable row id.
+    id: u64,
+    /// Similarity score (cosine / L2 / BM25 / hybrid, per query type).
+    score: f32,
+    /// Stored text, if the row carried any.
+    text: Option<String>,
+    /// Stored vector — `None` unless `search(..., include_vectors=True)`.
+    vector: Option<Vec<f32>>,
+    /// Server-side write timestamp (microseconds since the Unix epoch).
+    ingested_at_micros: Option<i64>,
+}
+
+impl From<QueryResult> for Hit {
+    fn from(r: QueryResult) -> Self {
+        Hit {
+            id: r.id,
+            score: r.score,
+            text: r.text,
+            vector: r.vector,
+            ingested_at_micros: r.ingested_at_micros,
+        }
+    }
+}
+
+#[pymethods]
+impl Hit {
+    fn __repr__(&self) -> String {
+        format!("Hit(id={}, score={:.4})", self.id, self.score)
+    }
+}
+
+/// Shared per-namespace bookkeeping held by a `Client` and every
+/// `Collection` it hands out, so they agree on which full-text indexes
+/// are current. Keyed by the resolved `NamespaceId` string.
+type FtsState = Arc<Mutex<HashSet<String>>>;
+
+/// Lifecycle gate shared by a `Client` and the `Collection`s it hands
+/// out. A data-plane call holds a read guard for its whole duration;
+/// `close()` takes the write guard, so it waits for in-flight operations
+/// to finish before shutting the cache down, and marks the client closed
+/// only once the cache actually closed (a failed close stays retryable).
+struct Lifecycle {
+    closed: AtomicBool,
+    gate: RwLock<()>,
+}
+
+impl Lifecycle {
+    fn new() -> Self {
+        Self {
+            closed: AtomicBool::new(false),
+            gate: RwLock::new(()),
+        }
+    }
+
+    /// Cheap, non-blocking check so a closed client rejects use before
+    /// any other validation. The authoritative, race-safe check is in
+    /// [`run`](Self::run).
+    fn check_open(&self) -> PyResult<()> {
+        if self.closed.load(Ordering::Acquire) {
+            Err(closed_py_err())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Run a blocking operation under a read guard. **The caller must
+    /// have released the GIL** — the gate is acquired here, so a thread
+    /// blocked waiting for it never holds the GIL (which would deadlock
+    /// against another thread needing the GIL to drop its guard).
+    /// Returns `None` if the client is closed; the read guard guarantees
+    /// `close()` is not running concurrently.
+    fn run<T>(
+        &self,
+        f: impl FnOnce() -> Result<T, FirnflowError>,
+    ) -> Result<Option<T>, FirnflowError> {
+        let _r = self.gate.read().unwrap_or_else(|p| p.into_inner());
+        if self.closed.load(Ordering::Acquire) {
+            return Ok(None);
+        }
+        f().map(Some)
+    }
+}
+
+/// The base `FirnError` raised on use-after-close.
+fn closed_py_err() -> PyErr {
+    FirnError::new_err("client is closed; open a new one with firn.connect()")
+}
+
+/// Validate one part of a namespace name (a collection or tenant) under
+/// the rules that keep the `--` tenant separator unambiguous: non-empty,
+/// `[a-z0-9-]`, no leading/trailing hyphen, no consecutive hyphens.
+fn validate_component(value: &str, what: &str) -> PyResult<()> {
+    if value.is_empty() {
+        return Err(TenantError::new_err(format!("{what} must not be empty")));
+    }
+    if !value
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(TenantError::new_err(format!(
+            "{what} {value:?} must contain only lowercase letters, digits, and hyphens"
+        )));
+    }
+    if value.starts_with('-') || value.ends_with('-') {
+        return Err(TenantError::new_err(format!(
+            "{what} {value:?} must not start or end with a hyphen"
+        )));
+    }
+    if value.contains("--") {
+        return Err(TenantError::new_err(format!(
+            "{what} {value:?} must not contain consecutive hyphens (\"--\" is reserved as the tenant separator)"
+        )));
+    }
+    Ok(())
+}
+
+/// Resolve a `(collection, tenant)` pair to a physical namespace.
+///
+/// With no tenant the namespace is the collection name; with a tenant it
+/// is `"{collection}--{tenant}"`. Because no component may contain `--`,
+/// the join is unambiguous and two distinct pairs can never collide on
+/// one namespace.
+fn compose_namespace(collection: &str, tenant: Option<&str>) -> PyResult<NamespaceId> {
+    validate_component(collection, "collection")?;
+    let name = match tenant {
+        None => collection.to_string(),
+        Some(t) => {
+            validate_component(t, "tenant")?;
+            format!("{collection}--{t}")
+        }
+    };
+    NamespaceId::new(name).map_err(to_py_err)
+}
+
+/// Convert a Python `list[dict]` into engine upsert rows under the GIL.
+fn parse_documents(documents: &Bound<'_, PyList>) -> PyResult<Vec<UpsertRow>> {
+    let mut rows = Vec::with_capacity(documents.len());
+    for item in documents.iter() {
+        let dict = item
+            .downcast::<PyDict>()
+            .map_err(|_| ValidationError::new_err("each document must be a dict"))?;
+        let id: u64 = dict
+            .get_item("id")?
+            .ok_or_else(|| {
+                ValidationError::new_err("document is missing the required integer 'id'")
+            })?
+            .extract()
+            .map_err(|_| {
+                ValidationError::new_err("document 'id' must be a non-negative integer")
+            })?;
+        let text: Option<String> = match dict.get_item("text")? {
+            Some(v) => Some(
+                v.extract()
+                    .map_err(|_| ValidationError::new_err("document 'text' must be a string"))?,
+            ),
+            None => None,
+        };
+        let vector: Vec<f32> = match dict.get_item("vector")? {
+            Some(v) => v.extract().map_err(|_| {
+                ValidationError::new_err("document 'vector' must be a list of numbers")
+            })?,
+            None => Vec::new(),
+        };
+        let vectors: Option<Vec<Vec<f32>>> = match dict.get_item("vectors")? {
+            Some(v) => {
+                let parsed: Vec<Vec<f32>> = v.extract().map_err(|_| {
+                    ValidationError::new_err(
+                        "document 'vectors' must be a list of lists of numbers",
+                    )
+                })?;
+                (!parsed.is_empty()).then_some(parsed)
+            }
+            None => None,
+        };
+        // Each row needs exactly one vector payload: a single `vector`
+        // or a multivector `vectors` bag, never both and never neither.
+        match (vector.is_empty(), vectors.is_some()) {
+            (false, true) => {
+                return Err(ValidationError::new_err(
+                    "document must set exactly one of 'vector' or 'vectors', not both",
+                ))
+            }
+            (true, false) => {
+                return Err(ValidationError::new_err(
+                    "document must include a 'vector' (list[float]) or 'vectors' \
+                     (list[list[float]]); firn stores vectors with optional 'text'",
+                ))
+            }
+            _ => {}
+        }
+        rows.push(UpsertRow {
+            id,
+            vector,
+            vectors,
+            text,
+        });
+    }
+    Ok(rows)
+}
+
+/// Ensure a BM25 full-text index exists for a namespace before a text
+/// or hybrid query. Built lazily and rebuilt after writes (tracked in
+/// `fts`); a namespace with no rows yet is a no-op, so the query simply
+/// returns no hits.
+fn ensure_fts_built(
+    service: &Arc<NamespaceService>,
+    fts: &FtsState,
+    ns: &NamespaceId,
+) -> Result<(), FirnflowError> {
+    if fts.lock().unwrap().contains(ns.as_str()) {
+        return Ok(());
+    }
+    match runtime().block_on(service.create_fts_index(ns)) {
+        Ok(()) => {
+            fts.lock().unwrap().insert(ns.as_str().to_string());
+            Ok(())
+        }
+        // No rows upserted yet: nothing to index. The query returns no
+        // hits. Any other failure is a real error.
+        Err(FirnflowError::InvalidRequest(_)) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Insert or update documents in a namespace (merge-insert by `id`).
+fn op_upsert(
+    service: &Arc<NamespaceService>,
+    fts: &FtsState,
+    lifecycle: &Arc<Lifecycle>,
+    py: Python<'_>,
+    ns: &NamespaceId,
+    documents: &Bound<'_, PyList>,
+) -> PyResult<usize> {
+    let rows = parse_documents(documents)?;
+    let n = rows.len();
+    let service = service.clone();
+    let lifecycle = lifecycle.clone();
+    let ns_owned = ns.clone();
+    let outcome = py
+        .allow_threads(move || {
+            lifecycle.run(|| runtime().block_on(service.upsert(&ns_owned, rows)))
+        })
+        .map_err(to_py_err)?;
+    if outcome.is_none() {
+        return Err(closed_py_err());
+    }
+    // New rows make any existing full-text index stale.
+    fts.lock().unwrap().remove(ns.as_str());
+    Ok(n)
+}
+
+/// Delete a whole namespace (all rows). Row-level delete by id is not
+/// supported by the engine yet.
+fn op_delete(
+    service: &Arc<NamespaceService>,
+    fts: &FtsState,
+    lifecycle: &Arc<Lifecycle>,
+    py: Python<'_>,
+    ns: &NamespaceId,
+) -> PyResult<usize> {
+    let service = service.clone();
+    let lifecycle = lifecycle.clone();
+    let ns_owned = ns.clone();
+    let count = py
+        .allow_threads(move || lifecycle.run(|| runtime().block_on(service.delete(&ns_owned))))
+        .map_err(to_py_err)?;
+    match count {
+        None => Err(closed_py_err()),
+        Some(c) => {
+            fts.lock().unwrap().remove(ns.as_str());
+            Ok(c)
+        }
+    }
+}
+
+/// Run a vector, full-text, or hybrid search against a namespace.
+#[allow(clippy::too_many_arguments)]
+fn op_search(
+    service: &Arc<NamespaceService>,
+    fts: &FtsState,
+    lifecycle: &Arc<Lifecycle>,
+    py: Python<'_>,
+    ns: &NamespaceId,
+    query: Option<String>,
+    vector: Option<Vec<f32>>,
+    vectors: Option<Vec<Vec<f32>>>,
+    hybrid: bool,
+    limit: usize,
+    include_vectors: bool,
+) -> PyResult<Vec<Hit>> {
+    // An empty list is "no payload", not an empty vector — otherwise a
+    // `vector=[]` would slip past the hybrid guard and silently degrade
+    // to FTS-only.
+    let vector = vector.filter(|v| !v.is_empty());
+    let vectors = vectors.filter(|v| !v.is_empty());
+    let has_vector = vector.is_some() || vectors.is_some();
+    if query.is_none() && !has_vector {
+        return Err(ValidationError::new_err(
+            "search needs a text query, a vector, or vectors",
+        ));
+    }
+    if vector.is_some() && vectors.is_some() {
+        return Err(ValidationError::new_err(
+            "set exactly one of 'vector' or 'vectors', not both",
+        ));
+    }
+    if hybrid && !has_vector {
+        return Err(ValidationError::new_err(
+            "hybrid=True needs a vector to fuse with the text query",
+        ));
+    }
+    let needs_fts = query.is_some();
+    let req = QueryRequest {
+        vector: vector.unwrap_or_default(),
+        vectors,
+        k: limit,
+        nprobes: None,
+        text: query,
+        include_vector: include_vectors,
+        semantic_cache: None,
+    };
+    let service = service.clone();
+    let fts = fts.clone();
+    let lifecycle = lifecycle.clone();
+    let ns_owned = ns.clone();
+    let result = py
+        .allow_threads(move || {
+            lifecycle.run(|| {
+                // Text and hybrid queries need a BM25 index; build it
+                // lazily. Vector-only search needs no index.
+                if needs_fts {
+                    ensure_fts_built(&service, &fts, &ns_owned)?;
+                }
+                runtime().block_on(service.query(&ns_owned, &req))
+            })
+        })
+        .map_err(to_py_err)?;
+    match result {
+        None => Err(closed_py_err()),
+        Some(rs) => Ok(rs.results.into_iter().map(Hit::from).collect()),
+    }
+}
+
+/// A handle to one named collection. Search and write methods take an
+/// optional `tenant=` that selects a physically separate namespace.
+#[pyclass]
+struct Collection {
+    service: Arc<NamespaceService>,
+    collection: String,
+    fts: FtsState,
+    lifecycle: Arc<Lifecycle>,
+}
+
+#[pymethods]
+impl Collection {
+    /// Insert or update documents. See `Client.add`.
+    #[pyo3(signature = (documents, *, tenant=None))]
+    fn add(
+        &self,
+        py: Python<'_>,
+        documents: &Bound<'_, PyList>,
+        tenant: Option<String>,
+    ) -> PyResult<usize> {
+        self.lifecycle.check_open()?;
+        let ns = compose_namespace(&self.collection, tenant.as_deref())?;
+        op_upsert(
+            &self.service,
+            &self.fts,
+            &self.lifecycle,
+            py,
+            &ns,
+            documents,
+        )
+    }
+
+    /// Alias for `add` (the engine write is an upsert by `id`).
+    #[pyo3(signature = (documents, *, tenant=None))]
+    fn upsert(
+        &self,
+        py: Python<'_>,
+        documents: &Bound<'_, PyList>,
+        tenant: Option<String>,
+    ) -> PyResult<usize> {
+        self.add(py, documents, tenant)
+    }
+
+    /// Delete the whole collection (optionally for one tenant). Passing
+    /// `ids` raises `UnsupportedError` — row-level delete is not yet
+    /// available.
+    #[pyo3(signature = (ids=None, *, tenant=None))]
+    fn delete(
+        &self,
+        py: Python<'_>,
+        ids: Option<Vec<u64>>,
+        tenant: Option<String>,
+    ) -> PyResult<usize> {
+        self.lifecycle.check_open()?;
+        if ids.is_some() {
+            return Err(UnsupportedError::new_err(
+                "row-level delete by id is not supported yet; call delete() with no ids to drop the whole collection",
+            ));
+        }
+        let ns = compose_namespace(&self.collection, tenant.as_deref())?;
+        op_delete(&self.service, &self.fts, &self.lifecycle, py, &ns)
+    }
+
+    /// Search this collection. See `Client.search`.
+    #[pyo3(signature = (query=None, *, vector=None, vectors=None, hybrid=false, limit=10, tenant=None, include_vectors=false))]
+    #[allow(clippy::too_many_arguments)]
+    fn search(
+        &self,
+        py: Python<'_>,
+        query: Option<String>,
+        vector: Option<Vec<f32>>,
+        vectors: Option<Vec<Vec<f32>>>,
+        hybrid: bool,
+        limit: usize,
+        tenant: Option<String>,
+        include_vectors: bool,
+    ) -> PyResult<Vec<Hit>> {
+        self.lifecycle.check_open()?;
+        let ns = compose_namespace(&self.collection, tenant.as_deref())?;
+        op_search(
+            &self.service,
+            &self.fts,
+            &self.lifecycle,
+            py,
+            &ns,
+            query,
+            vector,
+            vectors,
+            hybrid,
+            limit,
+            include_vectors,
+        )
+    }
+}
+
+/// An embedded firn client over a local or object-storage root. Proxies
+/// the data plane to a default collection and hands out named ones.
+#[pyclass]
+struct Client {
+    service: Arc<NamespaceService>,
+    cache: Arc<NamespaceCache>,
+    fts: FtsState,
+    lifecycle: Arc<Lifecycle>,
+}
+
+#[pymethods]
+impl Client {
+    /// Return a handle to a named collection.
+    fn collection(&self, name: String) -> PyResult<Collection> {
+        self.lifecycle.check_open()?;
+        validate_component(&name, "collection")?;
+        Ok(Collection {
+            service: self.service.clone(),
+            collection: name,
+            fts: self.fts.clone(),
+            lifecycle: self.lifecycle.clone(),
+        })
+    }
+
+    /// Insert or update documents in the default collection.
+    ///
+    /// Each document is a dict with an integer `id`, a `vector`
+    /// (list[float]), and optional `text` (str). `tenant=` writes to a
+    /// physically separate namespace. Returns the number of rows written.
+    #[pyo3(signature = (documents, *, tenant=None))]
+    fn add(
+        &self,
+        py: Python<'_>,
+        documents: &Bound<'_, PyList>,
+        tenant: Option<String>,
+    ) -> PyResult<usize> {
+        self.lifecycle.check_open()?;
+        let ns = compose_namespace(DEFAULT_COLLECTION, tenant.as_deref())?;
+        op_upsert(
+            &self.service,
+            &self.fts,
+            &self.lifecycle,
+            py,
+            &ns,
+            documents,
+        )
+    }
+
+    /// Alias for `add` (the engine write is an upsert by `id`).
+    #[pyo3(signature = (documents, *, tenant=None))]
+    fn upsert(
+        &self,
+        py: Python<'_>,
+        documents: &Bound<'_, PyList>,
+        tenant: Option<String>,
+    ) -> PyResult<usize> {
+        self.add(py, documents, tenant)
+    }
+
+    /// Delete the default collection (optionally for one tenant).
+    /// Passing `ids` raises `UnsupportedError`.
+    #[pyo3(signature = (ids=None, *, tenant=None))]
+    fn delete(
+        &self,
+        py: Python<'_>,
+        ids: Option<Vec<u64>>,
+        tenant: Option<String>,
+    ) -> PyResult<usize> {
+        self.lifecycle.check_open()?;
+        if ids.is_some() {
+            return Err(UnsupportedError::new_err(
+                "row-level delete by id is not supported yet; call delete() with no ids to drop the whole collection",
+            ));
+        }
+        let ns = compose_namespace(DEFAULT_COLLECTION, tenant.as_deref())?;
+        op_delete(&self.service, &self.fts, &self.lifecycle, py, &ns)
+    }
+
+    /// Search the default collection.
+    ///
+    /// `query` runs BM25 full-text search; `vector` runs
+    /// nearest-neighbour search; supplying both (or `hybrid=True`) runs
+    /// hybrid (RRF) search. `tenant=` scopes to one tenant's namespace.
+    /// Vectors are not echoed back on hits unless `include_vectors=True`.
+    #[pyo3(signature = (query=None, *, vector=None, vectors=None, hybrid=false, limit=10, tenant=None, include_vectors=false))]
+    #[allow(clippy::too_many_arguments)]
+    fn search(
+        &self,
+        py: Python<'_>,
+        query: Option<String>,
+        vector: Option<Vec<f32>>,
+        vectors: Option<Vec<Vec<f32>>>,
+        hybrid: bool,
+        limit: usize,
+        tenant: Option<String>,
+        include_vectors: bool,
+    ) -> PyResult<Vec<Hit>> {
+        self.lifecycle.check_open()?;
+        let ns = compose_namespace(DEFAULT_COLLECTION, tenant.as_deref())?;
+        op_search(
+            &self.service,
+            &self.fts,
+            &self.lifecycle,
+            py,
+            &ns,
+            query,
+            vector,
+            vectors,
+            hybrid,
+            limit,
+            include_vectors,
+        )
+    }
+
+    /// Flush the result cache's NVMe write buffer and release it. After
+    /// this the client and any collections from it reject use. Safe to
+    /// call more than once.
+    fn close(&self, py: Python<'_>) -> PyResult<()> {
+        let lifecycle = self.lifecycle.clone();
+        let cache = self.cache.clone();
+        py.allow_threads(move || -> Result<(), FirnflowError> {
+            // Wait for in-flight operations (the write guard), then close
+            // the cache, and mark closed only on success so a failed
+            // close stays retryable. A second close is a no-op.
+            let _w = lifecycle.gate.write().unwrap_or_else(|p| p.into_inner());
+            if lifecycle.closed.load(Ordering::Acquire) {
+                return Ok(());
+            }
+            runtime().block_on(cache.close())?;
+            lifecycle.closed.store(true, Ordering::Release);
+            Ok(())
+        })
+        .map_err(to_py_err)
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exc_type: Option<Bound<'_, PyAny>>,
+        _exc_value: Option<Bound<'_, PyAny>>,
+        _traceback: Option<Bound<'_, PyAny>>,
+    ) -> PyResult<bool> {
+        self.close(py)?;
+        Ok(false)
+    }
+}
+
+/// Platform cache directory for the foyer NVMe tier (Linux:
+/// `$XDG_CACHE_HOME` or `~/.cache`; macOS: `~/Library/Caches`). Kept out
+/// of the data directory so the cache is never committed alongside data.
+fn platform_cache_base() -> Option<PathBuf> {
+    if let Ok(x) = std::env::var("XDG_CACHE_HOME") {
+        if !x.is_empty() {
+            return Some(PathBuf::from(x));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    if cfg!(target_os = "macos") {
+        Some(PathBuf::from(home).join("Library").join("Caches"))
+    } else {
+        Some(PathBuf::from(home).join(".cache"))
+    }
+}
+
+/// Cache directory for a storage root, keyed by the root so two
+/// different datasets do not share a cache file. Created if absent.
+fn embedded_cache_dir(root: &StorageRoot) -> PyResult<PathBuf> {
+    let base = platform_cache_base().ok_or_else(|| {
+        StorageError::new_err(
+            "could not resolve a platform cache directory (set XDG_CACHE_HOME or HOME)",
+        )
+    })?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(&root.as_uri(), &mut hasher);
+    let dir = base
+        .join("firn")
+        .join(format!("{:016x}", std::hash::Hasher::finish(&hasher)));
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| StorageError::new_err(format!("create cache dir {}: {e}", dir.display())))?;
+    Ok(dir)
+}
+
+/// Build the S3-family storage options for an object-storage root from
+/// the explicit credential keyword arguments. Empty when none are
+/// given, in which case the underlying client reads the standard
+/// `AWS_*` environment.
+fn object_storage_options(
+    access_key: Option<String>,
+    secret_key: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+) -> HashMap<String, String> {
+    let mut opts = HashMap::new();
+    if let Some(k) = access_key {
+        opts.insert("aws_access_key_id".to_string(), k);
+    }
+    if let Some(s) = secret_key {
+        opts.insert("aws_secret_access_key".to_string(), s);
+    }
+    if let Some(r) = region {
+        opts.insert("aws_region".to_string(), r);
+    }
+    if let Some(e) = endpoint {
+        // A custom endpoint (Tigris, MinIO, R2, Spaces) needs path-style
+        // addressing; allow plain HTTP only for an `http://` endpoint.
+        let allow_http = e.starts_with("http://");
+        opts.insert("aws_endpoint".to_string(), e);
+        opts.insert(
+            "aws_virtual_hosted_style_request".to_string(),
+            "false".to_string(),
+        );
+        if allow_http {
+            opts.insert("allow_http".to_string(), "true".to_string());
+        }
+    }
+    opts
+}
+
+/// Storage URL configured through the environment, in precedence order:
+/// `FIRN_STORAGE_URL`, then the server's `FIRNFLOW_STORAGE_URI`, then a
+/// bare `FIRNFLOW_S3_BUCKET` (mapped to `s3://bucket`).
+fn env_storage_url() -> Option<String> {
+    for var in ["FIRN_STORAGE_URL", "FIRNFLOW_STORAGE_URI"] {
+        if let Ok(v) = std::env::var(var) {
+            if !v.trim().is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    std::env::var("FIRNFLOW_S3_BUCKET")
+        .ok()
+        .filter(|b| !b.trim().is_empty())
+        .map(|b| format!("s3://{b}"))
+}
+
+/// Open a firn client.
+///
+/// Storage is resolved in this order (the first that applies wins):
+/// 1. `storage_url` keyword (e.g. `s3://bucket[/prefix]`, `gs://bucket`).
+/// 2. `path` keyword — a local directory.
+/// 3. environment — `FIRN_STORAGE_URL`, then `FIRNFLOW_STORAGE_URI`,
+///    then `FIRNFLOW_S3_BUCKET`. S3 credentials come from the explicit
+///    keyword arguments or the standard `AWS_*` environment.
+/// 4. local default — `./firn_data` in the current working directory.
+///
+/// The directory or object-store prefix is created on first write.
+#[pyfunction]
+#[pyo3(signature = (
+    path=None,
+    *,
+    storage_url=None,
+    access_key=None,
+    secret_key=None,
+    endpoint=None,
+    region=None,
+))]
+fn connect(
+    py: Python<'_>,
+    path: Option<String>,
+    storage_url: Option<String>,
+    access_key: Option<String>,
+    secret_key: Option<String>,
+    endpoint: Option<String>,
+    region: Option<String>,
+) -> PyResult<Client> {
+    let (root, options) = if let Some(url) = storage_url {
+        (
+            StorageRoot::parse(&url).map_err(to_py_err)?,
+            object_storage_options(access_key, secret_key, endpoint, region),
+        )
+    } else if let Some(p) = path {
+        (StorageRoot::local(p).map_err(to_py_err)?, HashMap::new())
+    } else if let Some(url) = env_storage_url() {
+        (
+            StorageRoot::parse(&url).map_err(to_py_err)?,
+            object_storage_options(access_key, secret_key, endpoint, region),
+        )
+    } else {
+        (
+            StorageRoot::local("./firn_data").map_err(to_py_err)?,
+            HashMap::new(),
+        )
+    };
+
+    let metrics = Arc::new(CoreMetrics::new().map_err(to_py_err)?);
+    let manager = Arc::new(NamespaceManager::new(
+        root.clone(),
+        options,
+        Arc::clone(&metrics),
+    ));
+    let cache_dir = embedded_cache_dir(&root)?;
+    let cache = Arc::new(
+        py.allow_threads(|| {
+            runtime().block_on(NamespaceCache::new(
+                CACHE_MEMORY_BYTES,
+                &cache_dir,
+                CACHE_NVME_BYTES,
+                Arc::clone(&metrics),
+            ))
+        })
+        .map_err(to_py_err)?,
+    );
+    let service = Arc::new(NamespaceService::new(manager, Arc::clone(&cache), metrics));
+    Ok(Client {
+        service,
+        cache,
+        fts: Arc::new(Mutex::new(HashSet::new())),
+        lifecycle: Arc::new(Lifecycle::new()),
+    })
+}
+
+#[pymodule]
+fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(connect, m)?)?;
+    m.add_class::<Client>()?;
+    m.add_class::<Collection>()?;
+    m.add_class::<Hit>()?;
+    m.add("FirnError", m.py().get_type::<FirnError>())?;
+    m.add("StorageError", m.py().get_type::<StorageError>())?;
+    m.add("TenantError", m.py().get_type::<TenantError>())?;
+    m.add("ValidationError", m.py().get_type::<ValidationError>())?;
+    m.add("UnsupportedError", m.py().get_type::<UnsupportedError>())?;
+    Ok(())
+}

--- a/python/tests/test_firn.py
+++ b/python/tests/test_firn.py
@@ -1,0 +1,141 @@
+"""End-to-end tests for the firn package against local embedded mode.
+
+No server, no cloud — each test gets its own temp data dir and an
+isolated foyer cache (via XDG_CACHE_HOME).
+"""
+
+import firn
+import pytest
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    client = firn.connect(str(tmp_path / "data"))
+    yield client
+    client.close()
+
+
+def test_add_and_full_text(db):
+    db.add(
+        [
+            {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "text": "the quick brown fox"},
+            {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0], "text": "a lazy dog"},
+        ]
+    )
+    hits = db.search("fox")
+    assert hits and hits[0].id == 1
+
+
+def test_upsert_latest_wins(db):
+    db.add([{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "text": "old"}])
+    db.upsert([{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "text": "new"}])
+    hits = db.search(vector=[1.0, 0.0, 0.0, 0.0], limit=1)
+    assert hits[0].text == "new"
+
+
+def test_hybrid_guards(db):
+    db.add([{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "text": "fox"}])
+    with pytest.raises(firn.ValidationError):
+        db.search("fox", hybrid=True)  # no vector
+    with pytest.raises(firn.ValidationError):
+        db.search("fox", vector=[], hybrid=True)  # empty vector is not a vector
+
+
+def test_include_vectors(db):
+    db.add([{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "text": "x"}])
+    assert db.search(vector=[1.0, 0.0, 0.0, 0.0], limit=1)[0].vector is None
+    got = db.search(vector=[1.0, 0.0, 0.0, 0.0], limit=1, include_vectors=True)[0]
+    assert got.vector == [1.0, 0.0, 0.0, 0.0]
+
+
+def test_tenant_isolation(db):
+    db.add([{"id": 10, "vector": [1.0, 0.0, 0.0, 0.0], "text": "a"}], tenant="acme")
+    db.add([{"id": 20, "vector": [1.0, 0.0, 0.0, 0.0], "text": "b"}], tenant="globex")
+    a = {h.id for h in db.search(vector=[1.0, 0.0, 0.0, 0.0], limit=10, tenant="acme")}
+    b = {h.id for h in db.search(vector=[1.0, 0.0, 0.0, 0.0], limit=10, tenant="globex")}
+    assert a == {10}
+    assert b == {20}
+
+
+def test_bad_tenant_rejected(db):
+    with pytest.raises(firn.TenantError):
+        db.search(vector=[1.0, 0.0, 0.0, 0.0], tenant="bad_tenant")  # "_" is illegal
+
+
+def test_collection_isolation(db):
+    col = db.collection("products")
+    col.add([{"id": 5, "vector": [0.0, 0.0, 1.0, 0.0], "text": "widget"}])
+    assert {h.id for h in col.search("widget")} == {5}
+    assert not any(h.id == 5 for h in db.search("widget"))
+
+
+def test_delete(db):
+    db.add([{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "text": "x"}])
+    db.delete()
+    assert db.search(vector=[1.0, 0.0, 0.0, 0.0], limit=10) == []
+    with pytest.raises(firn.UnsupportedError):
+        db.delete(ids=[1])
+
+
+def test_multivector(db):
+    db.add(
+        [
+            {"id": 1, "vectors": [[1.0, 0.0], [1.0, 0.0]], "text": "a"},
+            {"id": 2, "vectors": [[0.0, 1.0], [0.0, 1.0]], "text": "b"},
+        ]
+    )
+    hits = db.search(vectors=[[1.0, 0.0]], limit=2)
+    assert hits[0].id == 1
+    assert hits[0].vector is None
+    with pytest.raises(firn.ValidationError):
+        db.add([{"id": 9, "vector": [1.0], "vectors": [[1.0]]}])  # both
+    with pytest.raises(firn.ValidationError):
+        db.add([{"id": 8, "text": "no vector"}])  # neither
+
+
+def test_close_is_idempotent_and_blocks_use(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    client = firn.connect(str(tmp_path / "data"))
+    client.add([{"id": 1, "vector": [1.0, 0.0], "text": "x"}])
+    client.close()
+    client.close()  # idempotent
+    with pytest.raises(firn.FirnError):
+        client.search(vector=[1.0, 0.0])
+    # Closed is checked before other validation: this is the closed
+    # error, not UnsupportedError from the ids guard.
+    with pytest.raises(firn.FirnError) as exc:
+        client.delete(ids=[1])
+    assert not isinstance(exc.value, firn.UnsupportedError)
+
+
+def test_concurrent_search_and_close(tmp_path, monkeypatch):
+    """Closing while searches run from other threads must not crash or
+    use the cache after close — the lifecycle gate makes close wait."""
+    import threading
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    client = firn.connect(str(tmp_path / "data"))
+    client.add([{"id": i, "vector": [float(i), 0.0], "text": "x"} for i in range(5)])
+
+    errors = []
+
+    def worker():
+        for _ in range(20):
+            try:
+                client.search(vector=[1.0, 0.0], limit=3)
+            except firn.FirnError:
+                return  # closed mid-run is fine
+            except Exception as e:  # nothing else should escape
+                errors.append(e)
+                return
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    client.close()  # races with in-flight searches
+    for t in threads:
+        t.join(timeout=10)
+    assert not errors, errors
+    with pytest.raises(firn.FirnError):
+        client.search(vector=[1.0, 0.0])

--- a/scripts/maturin
+++ b/scripts/maturin
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run maturin inside the pinned Rust + maturin dev container.
+#
+# Mirrors scripts/cargo: bind-mounts the project at /work and reuses the
+# shared cargo registry/git cache and build target so the PyO3 wheel
+# build stays incremental. maturin lives in the dev image (see
+# Dockerfile.dev); pyo3's build script and maturin both find the
+# container's python3.
+#
+# Typical use:
+#   ./scripts/maturin build -m python/Cargo.toml -o target/wheels
+#   ./scripts/maturin --version
+
+set -Eeuo pipefail
+
+IMAGE="firnflow-rust-dev:1.94"
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+    echo "Building ${IMAGE} (first run only)..." >&2
+    docker build -t "${IMAGE}" -f "${PROJECT_ROOT}/Dockerfile.dev" "${PROJECT_ROOT}" >&2
+fi
+
+mkdir -p "${PROJECT_ROOT}/.cargo-cache"
+
+exec docker run --rm --init \
+    --user "$(id -u):$(id -g)" \
+    -v "${PROJECT_ROOT}:/work" \
+    -e CARGO_HOME=/work/.cargo-cache \
+    -e CARGO_TARGET_DIR=/work/target \
+    -e CARGO_TERM_COLOR=always \
+    -w /work \
+    "${IMAGE}" \
+    maturin "$@"


### PR DESCRIPTION
## Summary

This adds `firn`, a Python package that runs the engine embedded in-process: `pip install firn`, then `firn.connect()` opens a client over a local directory or an object-storage bucket, no server.

The branch is four self-contained commits: an additive engine change (a local filesystem storage scheme), the package, two runnable examples, and the release workflow.

`add`/`upsert` take documents with an integer `id`, a `vector` (or a multivector bag), and optional `text`. `search` runs vector, BM25 full-text, or fused hybrid queries in one call, and `tenant=` selects a physically separate namespace. The same code runs against a local directory, AWS, Tigris, R2, MinIO, or GCS.

## Behavior notes

- The engine change is additive: `StorageRoot` gains a `Local` scheme (`file://` URIs plus a `local(path)` constructor) and `NamespaceManager` builds an `object_store` `LocalFileSystem` for it. S3 and GCS behavior is unchanged, and the server is untouched.
- The client goes through `NamespaceService` with its own foyer result cache (small RAM and NVMe tiers under the platform cache directory, not inside the data dir), so recurring queries are served from cache. `close()` flushes the NVMe buffer and then rejects further use.
- Coordinating `close()` with in-flight queries from other threads needed care: the lifecycle lock is taken only after the GIL is released, inside `allow_threads`. Taking it while holding the GIL deadlocks, because a thread blocked on the lock keeps the GIL that another thread needs to release its own guard.
- `tenant=` composes with the collection name as `collection--tenant`. Components are validated so the `--` separator stays unambiguous, which keeps tenant isolation physical rather than a filter a caller could forget.
- The crate sets `test = false` on its `[lib]`: a `cdylib` + `extension-module` crate would otherwise need to link libpython under the workspace-wide `cargo test`, and its behavior is covered by pytest instead.
- The release workflow triggers on its own `firn-v*` tags, separate from the server's `v*` tags, so the package versions independently (it is `0.1.0` while the server is `0.8.x`).
- Deferred for v0.1, by design: remote-server mode (`connect(url=...)`), guided provisioning, persisted `~/.firn/config.toml`, metadata `filter=`, row-level delete by id (the engine deletes whole namespaces), and Windows wheels (the local `file://` URI is Unix-shaped and untested there).

## Tests

~~~text
# workspace-wide on this branch (the CI commands)
./scripts/cargo fmt --all -- --check                                   # clean
./scripts/cargo clippy --workspace --all-targets -j 1 -- -D warnings   # clean

# engine change, no infra
./scripts/cargo test -p firnflow-core --test manager_local_fs -j 1     # 3 passed
./scripts/cargo test -p firnflow-core --lib storage_root -j 1          # passed

# python package
./scripts/cargo check -p firnflow-python -j 1                          # clean
./scripts/maturin build -m python/Cargo.toml -o target/wheels          # debug wheel built
pytest python/tests                                                    # 11 passed (installed wheel, fresh venv)

# live, against a real Tigris bucket (firn-tigris-bucket, t3.storage.dev, region=auto)
#   firn.connect(storage_url="s3://...") + add + full-text + vector + close: round-trip OK
#   examples/clip_search.py: OpenCLIP image search on Tigris, text->image and image->image: OK

Deliberately not run locally:
  - cargo test --workspace: the parallel link of every test binary against the Lance
    graph OOMs / fills disk on this 16 GB dev host. The engine change is covered by the
    two targeted runs above; CI runs the full workspace suite on the PR.
  - The release wheel matrix (manylinux x86_64/aarch64, macOS universal2) and the
    TestPyPI/PyPI publish: those run in pypi-publish.yml on a firn-v* tag. The build
    above is a local debug wheel, not the stripped release matrix.
~~~
