### PR TITLE
Add optional local-NVMe object cache for Lance reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,14 +2580,20 @@ version = "0.8.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "bincode 2.0.1",
+ "bytes",
+ "chrono",
  "dashmap",
+ "filetime",
  "foyer",
  "futures",
  "lance",
+ "lance-io",
  "lancedb",
+ "lru",
  "object_store 0.12.5",
  "prometheus",
  "serde",
@@ -2595,6 +2601,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "xxhash-rust",
 ]
 

--- a/crates/firnflow-api/src/config.rs
+++ b/crates/firnflow-api/src/config.rs
@@ -57,6 +57,20 @@ pub struct AppConfig {
     pub metrics_token: Option<Secret>,
     /// Rate-limiter knobs. `None` everywhere ⇒ both limiters off.
     pub rate_limit: RateLimitSettings,
+    /// Object cache (issue #51): when `true`, Lance object-store reads (index
+    /// and data byte ranges) are served from a local-NVMe cache, cutting S3
+    /// round-trips on warm/repeat/novel queries. `FIRNFLOW_OBJECT_CACHE_ENABLED`
+    /// (default off).
+    pub object_cache_enabled: bool,
+    /// Directory for the object cache. `FIRNFLOW_OBJECT_CACHE_DIR`.
+    pub object_cache_dir: PathBuf,
+    /// Object cache on-disk capacity in bytes (LRU eviction).
+    /// `FIRNFLOW_OBJECT_CACHE_BYTES` (default 10 GiB).
+    pub object_cache_bytes: u64,
+    /// Largest single read the object cache will buffer + cache; larger reads
+    /// stream straight through uncached, bounding the RAM one miss can use.
+    /// `FIRNFLOW_OBJECT_CACHE_MAX_ENTRY_BYTES` (default 256 MiB).
+    pub object_cache_max_entry_bytes: u64,
 }
 
 /// True when the given storage-options key holds credential-bearing
@@ -138,6 +152,20 @@ impl AppConfig {
             .parse()
             .context("FIRNFLOW_MAX_BODY_BYTES")?;
 
+        let object_cache_enabled = env_bool("FIRNFLOW_OBJECT_CACHE_ENABLED", false)?;
+        let object_cache_dir = PathBuf::from(env_or(
+            "FIRNFLOW_OBJECT_CACHE_DIR",
+            "/tmp/firnflow-object-cache",
+        ));
+        let object_cache_bytes: u64 = env_or("FIRNFLOW_OBJECT_CACHE_BYTES", "10737418240")
+            .parse()
+            .context("FIRNFLOW_OBJECT_CACHE_BYTES")?;
+        // Default 256 MiB; see firnflow_core::object_cache::DEFAULT_MAX_ENTRY_BYTES.
+        let object_cache_max_entry_bytes: u64 =
+            env_or("FIRNFLOW_OBJECT_CACHE_MAX_ENTRY_BYTES", "268435456")
+                .parse()
+                .context("FIRNFLOW_OBJECT_CACHE_MAX_ENTRY_BYTES")?;
+
         let storage_options = build_storage_options_for(storage_root.scheme());
 
         let api_key = optional_secret("FIRNFLOW_API_KEY");
@@ -168,6 +196,10 @@ impl AppConfig {
             admin_api_key,
             metrics_token,
             rate_limit,
+            object_cache_enabled,
+            object_cache_dir,
+            object_cache_bytes,
+            object_cache_max_entry_bytes,
         })
     }
 }
@@ -452,6 +484,10 @@ mod tests {
             admin_api_key: None,
             metrics_token: None,
             rate_limit: RateLimitSettings::default(),
+            object_cache_enabled: false,
+            object_cache_dir: std::env::temp_dir(),
+            object_cache_bytes: 0,
+            object_cache_max_entry_bytes: 0,
         };
 
         let dbg = format!("{:?}", cfg);
@@ -510,6 +546,10 @@ mod tests {
             admin_api_key: None,
             metrics_token: None,
             rate_limit: RateLimitSettings::default(),
+            object_cache_enabled: false,
+            object_cache_dir: std::env::temp_dir(),
+            object_cache_bytes: 0,
+            object_cache_max_entry_bytes: 0,
         };
 
         let dbg = format!("{:?}", cfg);

--- a/crates/firnflow-api/src/state.rs
+++ b/crates/firnflow-api/src/state.rs
@@ -79,11 +79,34 @@ pub async fn build_state(cfg: &AppConfig) -> anyhow::Result<AppState> {
     let metrics =
         Arc::new(CoreMetrics::new().map_err(|e| anyhow::anyhow!("build metrics registry: {e}"))?);
 
-    let manager = Arc::new(NamespaceManager::new(
+    let mut manager = NamespaceManager::new(
         cfg.storage_root.clone(),
         cfg.storage_options.clone(),
         Arc::clone(&metrics),
-    ));
+    );
+    if cfg.object_cache_enabled {
+        std::fs::create_dir_all(&cfg.object_cache_dir).with_context(|| {
+            format!(
+                "creating object cache directory {}",
+                cfg.object_cache_dir.display()
+            )
+        })?;
+        let mut oc_cfg = firnflow_core::object_cache::ObjectCacheConfig::new(
+            cfg.object_cache_dir.clone(),
+            cfg.object_cache_bytes,
+        );
+        oc_cfg.max_entry_bytes = cfg.object_cache_max_entry_bytes;
+        // Hand the registered object-cache counters in so hits/misses/evictions surface at /metrics.
+        let session =
+            firnflow_core::object_cache::build_cached_session(&oc_cfg, metrics.object_cache());
+        manager = manager.with_object_cache_session(session);
+        tracing::info!(
+            dir = %cfg.object_cache_dir.display(),
+            capacity_bytes = cfg.object_cache_bytes,
+            "object cache enabled (issue #51): Lance object-store reads served from local NVMe"
+        );
+    }
+    let manager = Arc::new(manager);
 
     std::fs::create_dir_all(&cfg.cache_nvme_path).with_context(|| {
         format!(

--- a/crates/firnflow-api/tests/api_auth.rs
+++ b/crates/firnflow-api/tests/api_auth.rs
@@ -257,6 +257,10 @@ async fn secret_debug_does_not_leak_in_app_config() {
         admin_api_key: Some(Secret::new("UNIQUE_ADMIN_KEY_PLEASE_DO_NOT_LEAK")),
         metrics_token: Some(Secret::new("UNIQUE_METRICS_KEY_PLEASE_DO_NOT_LEAK")),
         rate_limit: RateLimitSettings::default(),
+        object_cache_enabled: false,
+        object_cache_dir: std::env::temp_dir(),
+        object_cache_bytes: 0,
+        object_cache_max_entry_bytes: 0,
     };
     let dbg = format!("{:?}", cfg);
     assert!(
@@ -313,6 +317,10 @@ async fn duplicate_keys_fail_startup_before_cache_setup() {
         admin_api_key: Some(Secret::new("identical-token")),
         metrics_token: None,
         rate_limit: RateLimitSettings::default(),
+        object_cache_enabled: false,
+        object_cache_dir: std::env::temp_dir(),
+        object_cache_bytes: 0,
+        object_cache_max_entry_bytes: 0,
     };
 
     let err = match build_state(&cfg).await {

--- a/crates/firnflow-api/tests/common/mod.rs
+++ b/crates/firnflow-api/tests/common/mod.rs
@@ -183,6 +183,10 @@ pub fn dummy_config() -> AppConfig {
         admin_api_key: None,
         metrics_token: None,
         rate_limit: RateLimitSettings::default(),
+        object_cache_enabled: false,
+        object_cache_dir: std::env::temp_dir(),
+        object_cache_bytes: 0,
+        object_cache_max_entry_bytes: 0,
     }
 }
 

--- a/crates/firnflow-core/Cargo.toml
+++ b/crates/firnflow-core/Cargo.toml
@@ -22,11 +22,21 @@ futures.workspace = true
 bincode.workspace = true
 prometheus.workspace = true
 object_store.workspace = true
+# object cache (issue #51): byte-range NVMe cache wrapped under Lance via a
+# custom ObjectStoreProvider. lance-io provides the provider/registry traits;
+# the rest are needed to implement object_store::ObjectStore for the wrapper.
+lance-io = "=6.0.0"
+async-trait = "0.1"
+bytes = "1"
+chrono = "0.4"
+url = "2"
+lru = "0.16"
 
 [dev-dependencies]
 tempfile = "3"
 aws-config.workspace = true
 aws-sdk-s3.workspace = true
+filetime = "0.2"
 
 [[bench]]
 name = "serialisation"

--- a/crates/firnflow-core/src/lib.rs
+++ b/crates/firnflow-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod manager;
 pub mod metrics;
 pub mod namespace;
+pub mod object_cache;
 pub mod query;
 pub mod result;
 pub mod service;

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -177,6 +177,11 @@ pub struct NamespaceManager {
     /// namespace delete / index build / compaction.
     handles: DashMap<NamespaceId, NamespaceHandle>,
     metrics: Arc<CoreMetrics>,
+    /// Optional lance [`Session`] whose object-store registry wraps cloud
+    /// stores with the local-NVMe byte-range cache (issue #51). When set, it is
+    /// passed to every `lancedb::connect()` so Lance reads are served from the
+    /// cache. `None` disables the object cache (default).
+    object_cache_session: Option<Arc<lance::session::Session>>,
 }
 
 impl NamespaceManager {
@@ -210,7 +215,18 @@ impl NamespaceManager {
             schema_info: DashMap::new(),
             handles: DashMap::new(),
             metrics,
+            object_cache_session: None,
         }
+    }
+
+    /// Enable the local-NVMe object cache (issue #51) by supplying a lance
+    /// [`Session`] whose object-store registry wraps cloud reads with the
+    /// byte-range cache (build one via
+    /// [`crate::object_cache::build_cached_session`]). Every subsequent
+    /// `lancedb::connect()` routes its object-store reads through the cache.
+    pub fn with_object_cache_session(mut self, session: Arc<lance::session::Session>) -> Self {
+        self.object_cache_session = Some(session);
+        self
     }
 
     /// The configured storage root. Exposed for diagnostics and
@@ -366,8 +382,15 @@ impl NamespaceManager {
     }
 
     async fn connect(&self, ns: &NamespaceId) -> Result<lancedb::Connection, FirnflowError> {
-        lancedb::connect(&self.uri(ns))
-            .storage_options(self.storage_options.clone())
+        let mut builder =
+            lancedb::connect(&self.uri(ns)).storage_options(self.storage_options.clone());
+        if let Some(session) = &self.object_cache_session {
+            // Route Lance object-store reads through the local-NVMe byte-range
+            // cache (issue #51). Sharing one session across connections reuses
+            // the wrapped stores and their cache.
+            builder = builder.session(session.clone());
+        }
+        builder
             .execute()
             .await
             .map_err(|e| FirnflowError::Backend(format!("lancedb connect: {e}")))

--- a/crates/firnflow-core/src/metrics.rs
+++ b/crates/firnflow-core/src/metrics.rs
@@ -15,6 +15,11 @@
 //! * `firnflow_s3_requests_total{namespace, operation}`
 //! * `firnflow_cached_handles`
 //! * `firnflow_auth_rejections_total{reason}`
+//! * `firnflow_object_cache_hits_total`
+//! * `firnflow_object_cache_misses_total`
+//! * `firnflow_object_cache_inner_gets_total`
+//! * `firnflow_object_cache_s3_bytes_total`
+//! * `firnflow_object_cache_evictions_total`
 //!
 //! Constructed once at process start (in
 //! `firnflow-api::state::build_state`), wrapped in `Arc`, and
@@ -36,6 +41,7 @@ use prometheus::{
     Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, Registry, TextEncoder,
 };
 
+use crate::object_cache::ObjectCacheMetrics;
 use crate::{FirnflowError, NamespaceId};
 
 /// Process-wide metrics registry and typed handles.
@@ -58,6 +64,7 @@ pub struct CoreMetrics {
     compaction_duration: HistogramVec,
     cached_handles: IntGauge,
     auth_rejections: IntCounterVec,
+    object_cache: Arc<ObjectCacheMetrics>,
     seen_namespaces: DashSet<NamespaceId>,
 }
 
@@ -259,6 +266,11 @@ impl CoreMetrics {
             .register(Box::new(auth_rejections.clone()))
             .map_err(metrics_err)?;
 
+        // Object-cache (issue #51) byte-range cache counters, registered into the same registry so
+        // they surface at `/metrics`. Global (not per-namespace): the cache sits below the namespace
+        // abstraction in the object-store layer.
+        let object_cache = Arc::new(ObjectCacheMetrics::register(&registry).map_err(metrics_err)?);
+
         Ok(Self {
             registry,
             cache_hits,
@@ -274,6 +286,7 @@ impl CoreMetrics {
             compaction_duration,
             cached_handles,
             auth_rejections,
+            object_cache,
             seen_namespaces: DashSet::new(),
         })
     }
@@ -281,6 +294,13 @@ impl CoreMetrics {
     /// Borrow the underlying registry for the /metrics handler.
     pub fn registry(&self) -> &Registry {
         &self.registry
+    }
+
+    /// Shared object-cache counter handle, to hand to
+    /// `object_cache::build_cached_session`. Increments on it are
+    /// reflected in this registry's `/metrics` render.
+    pub fn object_cache(&self) -> Arc<ObjectCacheMetrics> {
+        self.object_cache.clone()
     }
 
     /// Serialise the current metric state as a Prometheus text

--- a/crates/firnflow-core/src/object_cache.rs
+++ b/crates/firnflow-core/src/object_cache.rs
@@ -1,0 +1,1113 @@
+//! Local-NVMe byte-range cache for Lance object-store reads (GitHub issue #51).
+//!
+//! Firn's existing result cache (`crate::cache`) only helps *exact repeated* queries. Profiling on
+//! real in-region S3 showed ~95% of cold *and* warm query latency is object-store I/O — a cold
+//! IVF_PQ query issues ~140 small GETs (mostly index), bound by request count, not bytes. This
+//! module caches the byte ranges Lance reads from object storage on local NVMe, so repeated /
+//! warm / non-identical queries over the same dataset are served locally instead of paying S3
+//! round-trips (a local-SSD cache in front of object storage; the approach #51 asks for).
+//!
+//! ## Integration
+//! Lance reads through `object_store::ObjectStore`. We wrap that store with [`CachingObjectStore`]
+//! by registering a [`CachingProvider`] (a `lance_io` `ObjectStoreProvider`) for the cloud schemes
+//! in a custom [`ObjectStoreRegistry`], wrapped in a [`lance::session::Session`] passed to lancedb's
+//! `connect().session(..)`. No fork of lance/lancedb — `ObjectStore.inner` is public, so the
+//! provider builds the real store and swaps in the cache.
+//!
+//! ## Correctness (why no write/delete invalidation is needed)
+//! We cache **only immutable, uniquely-named (write-once) objects** — Lance data fragments (`data/<uuid>.lance`)
+//! and index files (`_indices/<uuid>/...`). These are write-once and uniquely named, so:
+//!   * a namespace delete + recreate under the same path produces *new* UUIDs → new cache keys; old
+//!     entries are simply unreferenced orphans that are never served (and are reclaimed by LRU
+//!     eviction). NB `NamespaceManager::delete` deletes via a *separate* (uncached) object store, so
+//!     the cache never even sees those deletes — write-once unique naming is what keeps it correct.
+//!   * mutable / version-numbered paths (manifests, `_versions/`, `_transactions/`, `_latest`, the
+//!     "latest version" pointer) and `HEAD` requests are **never cached** — they pass straight
+//!     through. This is what makes write/delete invalidation unnecessary for correctness.
+//!
+//! Invalidation is therefore just capacity eviction, not coherence.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::path::{Path as FsPath, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{self, BoxStream, StreamExt};
+use lru::LruCache;
+use prometheus::{IntCounter, Opts, Registry};
+use tokio::fs;
+
+use object_store::path::Path as OPath;
+use object_store::{
+    Attributes, GetOptions, GetRange, GetResult, GetResultPayload, ListResult, MultipartUpload,
+    ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    Result as OResult,
+};
+
+use lance::Result as LanceResult;
+use lance_io::object_store::providers::ObjectStoreProvider;
+use lance_io::object_store::{
+    ObjectStore as LanceObjectStore, ObjectStoreParams, ObjectStoreRegistry,
+};
+
+/// Default per-entry buffering limit (256 MiB). A single cacheable read above this is streamed
+/// straight through rather than buffered + cached, so a whole-object read of a large fragment
+/// cannot spike RAM by the full object size.
+pub const DEFAULT_MAX_ENTRY_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Configuration for the object cache, sourced from operator env vars.
+#[derive(Clone, Debug)]
+pub struct ObjectCacheConfig {
+    /// Root directory on local NVMe for cached byte ranges.
+    pub dir: PathBuf,
+    /// Total on-disk capacity in bytes; LRU eviction keeps usage under this.
+    pub capacity_bytes: u64,
+    /// Largest single read that will be buffered and cached. Reads above this stream straight
+    /// through uncached, bounding the RAM a single miss can use.
+    pub max_entry_bytes: u64,
+    /// Cloud URI schemes whose stores should be cache-wrapped.
+    pub schemes: Vec<String>,
+}
+
+impl ObjectCacheConfig {
+    /// Build a config for the given cache directory and capacity, wrapping the
+    /// default cloud schemes (`s3`, `s3+ddb`, `gs`).
+    pub fn new(dir: PathBuf, capacity_bytes: u64) -> Self {
+        Self {
+            dir,
+            capacity_bytes,
+            max_entry_bytes: DEFAULT_MAX_ENTRY_BYTES,
+            schemes: vec!["s3".into(), "s3+ddb".into(), "gs".into()],
+        }
+    }
+}
+
+/// Process-wide counters for the object cache (shared across per-bucket stores).
+///
+/// Backed by Prometheus `IntCounter`s. When built via [`ObjectCacheMetrics::register`] the
+/// counters are registered with the core registry, so they surface at `/metrics` and can be
+/// scraped into Grafana. The counters are global (not per-namespace): the cache sits at the
+/// object-store layer, below the namespace abstraction, so it has no clean namespace label.
+#[derive(Clone, Debug)]
+pub struct ObjectCacheMetrics {
+    /// Reads that went to the inner (object storage) store — misses + uncacheable passthroughs.
+    pub inner_gets: IntCounter,
+    /// Reads served from the local cache.
+    pub hits: IntCounter,
+    /// Cacheable reads that missed, were fetched from object storage, and were written to the
+    /// local cache. Counted only after a successful cache admission.
+    pub misses: IntCounter,
+    /// Bytes fetched from object storage.
+    pub s3_bytes: IntCounter,
+    /// Cache entries evicted for capacity.
+    pub evictions: IntCounter,
+}
+
+impl ObjectCacheMetrics {
+    /// Create the object-cache counters and register them with `registry`.
+    ///
+    /// Increments on the returned handle are visible in the registry's `/metrics` render.
+    pub fn register(registry: &Registry) -> prometheus::Result<Self> {
+        let mk = |name: &str, help: &str| -> prometheus::Result<IntCounter> {
+            let counter = IntCounter::with_opts(Opts::new(name, help))?;
+            registry.register(Box::new(counter.clone()))?;
+            Ok(counter)
+        };
+        Ok(Self {
+            inner_gets: mk(
+                "firnflow_object_cache_inner_gets_total",
+                "Object-cache reads forwarded to object storage (misses + uncacheable passthroughs)",
+            )?,
+            hits: mk(
+                "firnflow_object_cache_hits_total",
+                "Object-cache reads served from the local disk cache",
+            )?,
+            misses: mk(
+                "firnflow_object_cache_misses_total",
+                "Object-cache cacheable reads that missed and were fetched + cached",
+            )?,
+            s3_bytes: mk(
+                "firnflow_object_cache_s3_bytes_total",
+                "Bytes fetched from object storage by the object cache",
+            )?,
+            evictions: mk(
+                "firnflow_object_cache_evictions_total",
+                "Object-cache entries evicted for capacity",
+            )?,
+        })
+    }
+
+    /// Standalone, unregistered counters — for tests and the disabled path.
+    pub fn unregistered() -> Self {
+        let mk = |name: &str| IntCounter::with_opts(Opts::new(name, name)).expect("counter opts");
+        Self {
+            inner_gets: mk("firnflow_object_cache_inner_gets_total"),
+            hits: mk("firnflow_object_cache_hits_total"),
+            misses: mk("firnflow_object_cache_misses_total"),
+            s3_bytes: mk("firnflow_object_cache_s3_bytes_total"),
+            evictions: mk("firnflow_object_cache_evictions_total"),
+        }
+    }
+
+    /// Return a point-in-time `(inner_gets, hits, misses, s3_bytes, evictions)` snapshot.
+    pub fn snapshot(&self) -> (u64, u64, u64, u64, u64) {
+        (
+            self.inner_gets.get(),
+            self.hits.get(),
+            self.misses.get(),
+            self.s3_bytes.get(),
+            self.evictions.get(),
+        )
+    }
+}
+
+impl Default for ObjectCacheMetrics {
+    fn default() -> Self {
+        Self::unregistered()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Byte-bounded LRU (O(1) touch/insert/evict via the `lru` crate; capacity in bytes)
+// ---------------------------------------------------------------------------
+
+struct ByteLru {
+    cap: u64,
+    used: u64,
+    map: LruCache<String, u64>, // key -> entry size in bytes; count-unbounded, byte-bounded here
+}
+
+impl ByteLru {
+    fn new(cap: u64) -> Self {
+        Self {
+            cap,
+            used: 0,
+            map: LruCache::unbounded(),
+        }
+    }
+    /// Mark `key` most-recently-used. O(1).
+    fn touch(&mut self, key: &str) {
+        let _ = self.map.get(key);
+    }
+    /// Admit a new entry; returns keys whose files must be deleted to honour the byte cap.
+    fn admit(&mut self, key: String, size: u64) -> Vec<String> {
+        if self.map.contains(&key) {
+            let _ = self.map.get(&key);
+            return Vec::new();
+        }
+        self.map.put(key, size);
+        self.used = self.used.saturating_add(size);
+        let mut evicted = Vec::new();
+        while self.used > self.cap {
+            match self.map.pop_lru() {
+                Some((k, sz)) => {
+                    self.used = self.used.saturating_sub(sz);
+                    evicted.push(k);
+                }
+                None => break,
+            }
+        }
+        evicted
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CachingObjectStore
+// ---------------------------------------------------------------------------
+
+/// Read-through byte-range cache over an inner object store. One per bucket
+/// (lance's registry reuses it across namespaces in the same bucket).
+pub struct CachingObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    dir: PathBuf,
+    /// Largest single read that will be buffered + cached; larger reads stream through uncached.
+    /// Clamped at construction to the cache capacity (an entry bigger than the whole cache could
+    /// never be retained).
+    max_entry_bytes: u64,
+    metrics: Arc<ObjectCacheMetrics>,
+    lru: Mutex<ByteLru>,
+    /// single-flight: one in-flight fetch per cache key; entries are removed once the
+    /// fetch completes and no other waiter holds the gate (see `release_inflight`).
+    inflight: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+}
+
+impl std::fmt::Debug for CachingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CachingObjectStore({:?})", self.inner)
+    }
+}
+impl std::fmt::Display for CachingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CachingObjectStore({})", self.inner)
+    }
+}
+
+fn hash_key(parts: &[&str]) -> String {
+    // DefaultHasher is deterministic across processes (fixed seed) → stable keys across restarts.
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    for p in parts {
+        p.hash(&mut h);
+        0u8.hash(&mut h);
+    }
+    format!("{:016x}", h.finish())
+}
+
+fn sz_path(p: &FsPath) -> PathBuf {
+    p.with_extension("sz")
+}
+
+impl CachingObjectStore {
+    /// Wrap `inner` with a read-through byte-range cache stored under `dir`, bounded to
+    /// `capacity_bytes` (LRU eviction), recording into `metrics`. The cache directory is scanned on
+    /// construction so pre-existing entries count toward the byte cap (durable across restarts and
+    /// store re-creation; over-cap files are evicted immediately).
+    pub fn new(
+        inner: Arc<dyn ObjectStore>,
+        dir: PathBuf,
+        capacity_bytes: u64,
+        max_entry_bytes: u64,
+        metrics: Arc<ObjectCacheMetrics>,
+    ) -> Self {
+        let _ = std::fs::create_dir_all(&dir);
+        let mut lru = ByteLru::new(capacity_bytes);
+
+        // Startup scan: admit existing cache files (oldest first) so capacity is honoured across
+        // restarts / dropped-and-recreated stores. `.sz` sidecars are auxiliary; `.tmp` files are
+        // stale partial writes from a crash/failed rename — they aren't counted toward the cap, so
+        // delete them now rather than leak uncounted (possibly large) bytes.
+        let mut found: Vec<(String, u64, SystemTime)> = Vec::new();
+        if let Ok(rd) = std::fs::read_dir(&dir) {
+            for ent in rd.flatten() {
+                let name = match ent.file_name().to_str() {
+                    Some(n) => n.to_string(),
+                    None => continue,
+                };
+                if name.ends_with(".tmp") {
+                    let _ = std::fs::remove_file(ent.path());
+                    continue;
+                }
+                if name.ends_with(".sz") {
+                    continue;
+                }
+                if let Ok(meta) = ent.metadata() {
+                    if meta.is_file() {
+                        let mt = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+                        found.push((name, meta.len(), mt));
+                    }
+                }
+            }
+        }
+        found.sort_by_key(|(_, _, mt)| *mt);
+        for (name, size, _) in found {
+            for k in lru.admit(name, size) {
+                let _ = std::fs::remove_file(dir.join(&k));
+                let _ = std::fs::remove_file(sz_path(&dir.join(&k)));
+            }
+        }
+
+        Self {
+            inner,
+            dir,
+            // An entry larger than the whole cache could never be retained (the LRU would evict it
+            // immediately), so never buffer one: the effective limit is the smaller of the two.
+            max_entry_bytes: max_entry_bytes.min(capacity_bytes),
+            metrics,
+            lru: Mutex::new(lru),
+            inflight: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn key_path(&self, location: &OPath, range: Option<(u64, u64)>) -> (String, PathBuf) {
+        let r = match range {
+            Some((s, e)) => format!("{s}-{e}"),
+            None => "whole".to_string(),
+        };
+        let key = hash_key(&[location.as_ref(), &r]);
+        let path = self.dir.join(&key);
+        (key, path)
+    }
+
+    fn inflight_lock(&self, key: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.inflight
+            .lock()
+            .unwrap()
+            .entry(key.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    /// Remove the single-flight entry once no other waiter holds the gate. Both this and
+    /// `inflight_lock` hold the map lock, so the strong-count check is race-free (no new waiter can
+    /// clone the gate while we hold the lock). `gate` strong count is 2 (map + our clone) when we
+    /// are the last holder.
+    fn release_inflight(&self, key: &str, gate: &Arc<tokio::sync::Mutex<()>>) {
+        let mut m = self.inflight.lock().unwrap();
+        if Arc::strong_count(gate) <= 2 {
+            m.remove(key);
+        }
+    }
+
+    async fn admit_file(&self, key: String, size: u64) {
+        let evicted = self.lru.lock().unwrap().admit(key, size);
+        for k in evicted {
+            let p = self.dir.join(&k);
+            let _ = fs::remove_file(&p).await;
+            let _ = fs::remove_file(sz_path(&p)).await;
+            self.metrics.evictions.inc();
+        }
+    }
+
+    /// Try to serve `(location, range)` from disk. Returns the result on a hit.
+    async fn disk_hit(
+        &self,
+        key: &str,
+        path: &FsPath,
+        location: &OPath,
+        range: Option<(u64, u64)>,
+    ) -> Option<GetResult> {
+        // Require the size sidecar first. A payload without it (a crash between rename and sidecar
+        // write, or a failed sidecar write) would otherwise be served with a wrong object size on a
+        // range read, so treat it as a miss — and read the small sidecar before the payload so we
+        // don't read a potentially large orphan just to reject it.
+        let obj_size = fs::read_to_string(sz_path(path))
+            .await
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())?;
+        let bytes = fs::read(path).await.ok()?;
+        self.metrics.hits.inc();
+        self.lru.lock().unwrap().touch(key);
+        Some(build_result(location.clone(), bytes, range, Some(obj_size)))
+    }
+}
+
+/// Cache only immutable, uniquely-named (write-once) objects (data fragments + index files). Everything else
+/// — mutable / version-numbered metadata and the latest-version pointer — is never cached.
+fn should_cache(location: &OPath) -> bool {
+    let p = location.as_ref();
+    if p.contains("_versions")
+        || p.contains("_transactions")
+        || p.contains("_latest")
+        || p.ends_with(".manifest")
+    {
+        return false;
+    }
+    p.contains("_indices") || p.contains("/data/") || p.ends_with(".lance")
+}
+
+/// Whether a `GetOptions` is a plain (cacheable) read: not a HEAD, no conditional headers, no
+/// explicit object version, and a whole-object or bounded-range read (offset/suffix pass through
+/// uncached). The cache key is `(path, range)` only, so anything that changes the bytes a given
+/// `(path, range)` resolves to — a HEAD (metadata, no body), a conditional, or a `version` — must
+/// not be cached, or it would collide with a plain read of the same key.
+fn plain_read(o: &GetOptions) -> bool {
+    if o.head
+        || o.version.is_some()
+        || o.if_match.is_some()
+        || o.if_none_match.is_some()
+        || o.if_modified_since.is_some()
+        || o.if_unmodified_since.is_some()
+    {
+        return false;
+    }
+    matches!(o.range, None | Some(GetRange::Bounded(_)))
+}
+
+fn bounded_or_whole(o: &GetOptions) -> Option<(u64, u64)> {
+    match &o.range {
+        Some(GetRange::Bounded(r)) => Some((r.start, r.end)),
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl ObjectStore for CachingObjectStore {
+    async fn get_opts(&self, location: &OPath, options: GetOptions) -> OResult<GetResult> {
+        if !should_cache(location) || !plain_read(&options) {
+            self.metrics.inner_gets.inc();
+            return self.inner.get_opts(location, options).await;
+        }
+        let range = bounded_or_whole(&options);
+        let (key, path) = self.key_path(location, range);
+
+        // fast path
+        if let Some(hit) = self.disk_hit(&key, &path, location, range).await {
+            return Ok(hit);
+        }
+
+        // single-flight: serialize concurrent identical misses, then self-clean.
+        let gate = self.inflight_lock(&key);
+        let _g = gate.lock().await;
+        let out = if let Some(hit) = self.disk_hit(&key, &path, location, range).await {
+            Ok(hit)
+        } else {
+            self.fetch_and_cache(location, options, &key, &path).await
+        };
+        drop(_g);
+        self.release_inflight(&key, &gate);
+        out
+    }
+
+    async fn put_opts(&self, l: &OPath, p: PutPayload, o: PutOptions) -> OResult<PutResult> {
+        self.inner.put_opts(l, p, o).await
+    }
+    async fn put_multipart_opts(
+        &self,
+        l: &OPath,
+        o: PutMultipartOptions,
+    ) -> OResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(l, o).await
+    }
+    async fn delete(&self, l: &OPath) -> OResult<()> {
+        self.inner.delete(l).await
+    }
+    fn list(&self, prefix: Option<&OPath>) -> BoxStream<'static, OResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+    async fn list_with_delimiter(&self, prefix: Option<&OPath>) -> OResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+    async fn copy(&self, from: &OPath, to: &OPath) -> OResult<()> {
+        self.inner.copy(from, to).await
+    }
+    async fn copy_if_not_exists(&self, from: &OPath, to: &OPath) -> OResult<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}
+
+impl CachingObjectStore {
+    async fn fetch_and_cache(
+        &self,
+        location: &OPath,
+        options: GetOptions,
+        key: &str,
+        path: &FsPath,
+    ) -> OResult<GetResult> {
+        self.metrics.inner_gets.inc();
+        let res = self.inner.get_opts(location, options).await?;
+
+        // Bound the buffered read. A whole-object (or large-range) read of a big fragment would
+        // otherwise spike RAM by the full size: above the per-entry limit we stream the inner
+        // result straight back to Lance without buffering or caching it.
+        let returned_len = res.range.end.saturating_sub(res.range.start);
+        if returned_len > self.max_entry_bytes {
+            return Ok(res);
+        }
+
+        let meta = res.meta.clone();
+        let attrs = res.attributes.clone();
+        let actual = res.range.clone();
+        let bytes = res.bytes().await?;
+        self.metrics.s3_bytes.inc_by(bytes.len() as u64);
+
+        // Count a miss only once the bytes are durably cached, so the metric means
+        // "fetched and cached" — a failed disk write (or an over-limit passthrough above) is not
+        // counted as a miss and so never inflates the hit-rate denominator. Always remove the temp
+        // file on a failed write/rename so a partial write can't leak uncounted bytes past the cap.
+        let tmp = path.with_extension("tmp");
+        let cached = match fs::write(&tmp, &bytes).await {
+            Ok(()) => match fs::rename(&tmp, path).await {
+                Ok(()) => true,
+                Err(_) => {
+                    let _ = fs::remove_file(&tmp).await;
+                    false
+                }
+            },
+            Err(_) => {
+                let _ = fs::remove_file(&tmp).await;
+                false
+            }
+        };
+        if cached {
+            // Retain the payload only alongside its size sidecar — a payload without it is unservable
+            // (see `disk_hit`). If the sidecar write fails, drop the payload so it doesn't sit on
+            // disk counting toward the cap while never being served.
+            if fs::write(sz_path(path), meta.size.to_string())
+                .await
+                .is_ok()
+            {
+                self.admit_file(key.to_string(), bytes.len() as u64).await;
+                self.metrics.misses.inc();
+            } else {
+                let _ = fs::remove_file(path).await;
+            }
+        }
+        Ok(GetResult {
+            payload: one_chunk(bytes),
+            meta,
+            range: actual,
+            attributes: attrs,
+        })
+    }
+}
+
+fn one_chunk(b: Bytes) -> GetResultPayload {
+    GetResultPayload::Stream(stream::once(async move { Ok(b) }).boxed())
+}
+
+fn build_result(
+    location: OPath,
+    bytes: Vec<u8>,
+    range: Option<(u64, u64)>,
+    obj_size: Option<u64>,
+) -> GetResult {
+    let bytes = Bytes::from(bytes);
+    let len = bytes.len() as u64;
+    let start = range.map(|(s, _)| s).unwrap_or(0);
+    let meta = ObjectMeta {
+        location,
+        last_modified: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+        size: obj_size.unwrap_or(len),
+        e_tag: None,
+        version: None,
+    };
+    GetResult {
+        payload: one_chunk(bytes),
+        meta,
+        range: start..start + len,
+        attributes: Attributes::default(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CachingProvider — wraps a real provider's store with the cache
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct CachingProvider {
+    inner: Arc<dyn ObjectStoreProvider>,
+    cfg: ObjectCacheConfig,
+    metrics: Arc<ObjectCacheMetrics>,
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+#[async_trait]
+impl ObjectStoreProvider for CachingProvider {
+    async fn new_store(
+        &self,
+        base_path: url::Url,
+        params: &ObjectStoreParams,
+    ) -> LanceResult<LanceObjectStore> {
+        let mut store = self.inner.new_store(base_path.clone(), params).await?;
+        let prefix = self
+            .inner
+            .calculate_object_store_prefix(&base_path, params.storage_options())?;
+        let cache = CachingObjectStore::new(
+            store.inner.clone(),
+            self.cfg.dir.join(sanitize(&prefix)),
+            self.cfg.capacity_bytes,
+            self.cfg.max_entry_bytes,
+            self.metrics.clone(),
+        );
+        store.inner = Arc::new(cache);
+        Ok(store)
+    }
+
+    fn extract_path(&self, url: &url::Url) -> LanceResult<OPath> {
+        self.inner.extract_path(url)
+    }
+
+    fn calculate_object_store_prefix(
+        &self,
+        url: &url::Url,
+        storage_options: Option<&HashMap<String, String>>,
+    ) -> LanceResult<String> {
+        self.inner
+            .calculate_object_store_prefix(url, storage_options)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Session builder — what manager.rs hands to lancedb connect().session(..)
+// ---------------------------------------------------------------------------
+
+/// Build a lance [`Session`](lance::session::Session) whose object-store registry wraps cloud
+/// stores with the byte-range cache, recording into `metrics`. Pass the returned session to
+/// `lancedb::connect(..).session(session)`. Hand in `CoreMetrics::object_cache()` so the counters
+/// surface at `/metrics`, or [`ObjectCacheMetrics::unregistered`] when you don't need them scraped.
+pub fn build_cached_session(
+    cfg: &ObjectCacheConfig,
+    metrics: Arc<ObjectCacheMetrics>,
+) -> Arc<lance::session::Session> {
+    let registry = ObjectStoreRegistry::default();
+    for scheme in &cfg.schemes {
+        if let Some(inner) = registry.get_provider(scheme) {
+            registry.insert(
+                scheme,
+                Arc::new(CachingProvider {
+                    inner,
+                    cfg: cfg.clone(),
+                    metrics: metrics.clone(),
+                }),
+            );
+        }
+    }
+    let session = lance::session::Session::new(
+        lance::dataset::DEFAULT_INDEX_CACHE_SIZE,
+        lance::dataset::DEFAULT_METADATA_CACHE_SIZE,
+        Arc::new(registry),
+    );
+    Arc::new(session)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+
+    fn cache(
+        dir: &FsPath,
+        inner: Arc<dyn ObjectStore>,
+    ) -> (CachingObjectStore, Arc<ObjectCacheMetrics>) {
+        let m = Arc::new(ObjectCacheMetrics::default());
+        (
+            CachingObjectStore::new(
+                inner,
+                dir.to_path_buf(),
+                64 * 1024 * 1024,
+                u64::MAX,
+                m.clone(),
+            ),
+            m,
+        )
+    }
+
+    #[tokio::test]
+    async fn caches_immutable_range_and_serves_repeat_from_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/abc.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![7u8; 1024 * 1024]))
+            .await
+            .unwrap();
+        let (c, m) = cache(tmp.path(), inner);
+
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(0..65_536)),
+            ..Default::default()
+        };
+        let a = c
+            .get_opts(&loc, opts.clone())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let b = c.get_opts(&loc, opts).await.unwrap().bytes().await.unwrap();
+        assert_eq!(a, b);
+        let (inner_gets, hits, misses, _, _) = m.snapshot();
+        assert_eq!(
+            (inner_gets, hits, misses),
+            (1, 1, 1),
+            "miss then hit, inner touched once"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_register_and_increment_via_registry() {
+        use prometheus::{Encoder, TextEncoder};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/abc.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![3u8; 4096]))
+            .await
+            .unwrap();
+
+        // Counters registered with a real registry (mirrors CoreMetrics wiring).
+        let registry = Registry::new();
+        let m = Arc::new(ObjectCacheMetrics::register(&registry).unwrap());
+        let c = CachingObjectStore::new(
+            inner,
+            tmp.path().to_path_buf(),
+            64 * 1024 * 1024,
+            u64::MAX,
+            m.clone(),
+        );
+
+        // Miss then hit on the same immutable range.
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(0..4096)),
+            ..Default::default()
+        };
+        let _ = c
+            .get_opts(&loc, opts.clone())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let _ = c.get_opts(&loc, opts).await.unwrap().bytes().await.unwrap();
+
+        // Counters moved on the handle...
+        let (inner_gets, hits, misses, s3_bytes, _) = m.snapshot();
+        assert_eq!((inner_gets, hits, misses), (1, 1, 1));
+        assert_eq!(s3_bytes, 4096);
+
+        // ...and are exposed in the registry's `/metrics` render with the same values.
+        let mut buf = Vec::new();
+        TextEncoder::new()
+            .encode(&registry.gather(), &mut buf)
+            .unwrap();
+        let text = String::from_utf8(buf).unwrap();
+        assert!(
+            text.contains("firnflow_object_cache_hits_total 1"),
+            "hits not exposed:\n{text}"
+        );
+        assert!(text.contains("firnflow_object_cache_misses_total 1"));
+        assert!(text.contains("firnflow_object_cache_inner_gets_total 1"));
+        assert!(text.contains("firnflow_object_cache_s3_bytes_total 4096"));
+    }
+
+    #[tokio::test]
+    async fn reads_over_the_entry_limit_stream_through_uncached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/big.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![1u8; 200_000]))
+            .await
+            .unwrap();
+
+        // Tiny per-entry limit: a whole-object read of a 200 KB fragment exceeds it and must be
+        // streamed straight through, never buffered to a cache file.
+        let m = Arc::new(ObjectCacheMetrics::default());
+        let c = CachingObjectStore::new(
+            inner,
+            tmp.path().to_path_buf(),
+            64 * 1024 * 1024,
+            1024,
+            m.clone(),
+        );
+
+        let a = c
+            .get_opts(&loc, GetOptions::default())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let b = c
+            .get_opts(&loc, GetOptions::default())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(a.len(), 200_000, "full object still served");
+        assert_eq!(a, b, "second read returns the same bytes");
+
+        let (inner_gets, hits, misses, _, _) = m.snapshot();
+        assert_eq!(hits, 0, "over-limit reads are never served from the cache");
+        assert_eq!(
+            misses, 0,
+            "over-limit reads are never admitted, so never counted as cached"
+        );
+        assert_eq!(inner_gets, 2, "both reads were forwarded to the backend");
+
+        // No cache entry file was written (only `.sz`/`.tmp` would be auxiliary, and none should exist).
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                let n = e.file_name();
+                let n = n.to_string_lossy();
+                !n.ends_with(".sz") && !n.ends_with(".tmp")
+            })
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "no cache file should be written for an over-limit read"
+        );
+    }
+
+    #[tokio::test]
+    async fn reads_over_capacity_stream_through_even_under_entry_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/big.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![2u8; 200_000]))
+            .await
+            .unwrap();
+
+        // The entry limit (256 MiB) is far above the 64 KiB cap, so the effective limit is the cap:
+        // a 200 KB read could never be retained and so is never buffered, written, or counted.
+        let m = Arc::new(ObjectCacheMetrics::default());
+        let c = CachingObjectStore::new(
+            inner,
+            tmp.path().to_path_buf(),
+            64 * 1024,
+            256 * 1024 * 1024,
+            m.clone(),
+        );
+
+        let _ = c
+            .get_opts(&loc, GetOptions::default())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let (inner_gets, hits, misses, _, _) = m.snapshot();
+        assert_eq!(
+            (hits, misses),
+            (0, 0),
+            "over-capacity read is never cached nor counted"
+        );
+        assert_eq!(inner_gets, 1, "the read was forwarded to the backend");
+        let files = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                let n = e.file_name();
+                let n = n.to_string_lossy();
+                !n.ends_with(".sz") && !n.ends_with(".tmp")
+            })
+            .count();
+        assert_eq!(files, 0, "nothing written for an over-capacity read");
+    }
+
+    #[tokio::test]
+    async fn payload_without_sidecar_is_not_served() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/abc.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![7u8; 4096]))
+            .await
+            .unwrap();
+        let (c, m) = cache(tmp.path(), inner);
+
+        // Plant a payload file for the whole-object key but no `.sz` sidecar — i.e. an orphan from a
+        // crash between rename and sidecar write. It must NOT be served as a hit.
+        let (_key, path) = c.key_path(&loc, None);
+        std::fs::write(&path, vec![0u8; 4096]).unwrap();
+
+        let got = c
+            .get_opts(&loc, GetOptions::default())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(
+            &got[..],
+            &vec![7u8; 4096][..],
+            "must serve the real bytes, not the sidecar-less orphan"
+        );
+        let (_, hits, misses, _, _) = m.snapshot();
+        assert_eq!(
+            hits, 0,
+            "a payload without its sidecar must not count as a hit"
+        );
+        assert_eq!(
+            misses, 1,
+            "it re-fetched from the backend and cached properly"
+        );
+        // After re-fetch the sidecar now exists, so a repeat read is a real hit.
+        let _ = c
+            .get_opts(&loc, GetOptions::default())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(
+            m.snapshot().1,
+            1,
+            "repeat read is now a hit (sidecar present)"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_scan_removes_stale_tmp_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // A large leftover .tmp from a crashed write, plus a legitimate payload file.
+        std::fs::write(dir.join("deadbeef.tmp"), vec![0u8; 500_000]).unwrap();
+        std::fs::write(dir.join("cafef00d"), vec![1u8; 1024]).unwrap();
+
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let m = Arc::new(ObjectCacheMetrics::default());
+        let c = CachingObjectStore::new(inner, dir.to_path_buf(), 64 * 1024 * 1024, u64::MAX, m);
+
+        assert!(
+            !dir.join("deadbeef.tmp").exists(),
+            "stale .tmp must be deleted on startup, not leaked uncounted"
+        );
+        let used = c.lru.lock().unwrap().used;
+        assert_eq!(
+            used, 1024,
+            "only the real payload counts toward the cap, not the .tmp leftover"
+        );
+    }
+
+    #[tokio::test]
+    async fn head_requests_are_never_cached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/abc.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![9u8; 4096]))
+            .await
+            .unwrap();
+        let (c, m) = cache(tmp.path(), inner);
+
+        // HEAD must pass through and must NOT populate the whole-object cache key.
+        let head = GetOptions {
+            head: true,
+            ..Default::default()
+        };
+        let _ = c.get_opts(&loc, head).await.unwrap();
+        // a real whole-object GET must then fetch the genuine bytes (a miss), not a poisoned hit.
+        let full = c
+            .get_opts(&loc, GetOptions::default())
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!(
+            full.len(),
+            4096,
+            "real object served, not a HEAD-poisoned entry"
+        );
+        let (_, hits, misses, _, _) = m.snapshot();
+        assert_eq!(
+            (hits, misses),
+            (0, 1),
+            "HEAD passthrough left no cache entry; GET is a clean miss"
+        );
+    }
+
+    #[tokio::test]
+    async fn mutable_metadata_is_not_cached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest = OPath::from("ns/_versions/1.manifest");
+        inner
+            .put(&manifest, PutPayload::from(vec![1u8; 256]))
+            .await
+            .unwrap();
+        let (c, m) = cache(tmp.path(), inner);
+
+        let _ = c.get_opts(&manifest, GetOptions::default()).await.unwrap();
+        let _ = c.get_opts(&manifest, GetOptions::default()).await.unwrap();
+        let (inner_gets, hits, _, _, _) = m.snapshot();
+        assert_eq!(
+            hits, 0,
+            "manifests must never be cached (mutable/version-numbered)"
+        );
+        assert_eq!(
+            inner_gets, 2,
+            "both manifest reads passed through to the inner store"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_scan_counts_existing_files_toward_capacity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/abc.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![5u8; 1024 * 1024]))
+            .await
+            .unwrap();
+
+        // First store with a tiny cap caches one entry.
+        {
+            let m = Arc::new(ObjectCacheMetrics::default());
+            let c = CachingObjectStore::new(
+                inner.clone(),
+                tmp.path().to_path_buf(),
+                256 * 1024,
+                u64::MAX,
+                m,
+            );
+            let opts = GetOptions {
+                range: Some(GetRange::Bounded(0..200_000)),
+                ..Default::default()
+            };
+            let _ = c.get_opts(&loc, opts).await.unwrap().bytes().await.unwrap();
+        }
+        // A fresh store over the same dir must account for the on-disk file (used > 0), so a tiny
+        // cap can't grow unbounded across restart.
+        let m = Arc::new(ObjectCacheMetrics::default());
+        let c = CachingObjectStore::new(inner, tmp.path().to_path_buf(), 256 * 1024, u64::MAX, m);
+        let used = c.lru.lock().unwrap().used;
+        assert!(
+            used > 0,
+            "startup scan must admit pre-existing files toward capacity, got {used}"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_scan_evicts_over_cap_oldest_first() {
+        use filetime::{set_file_mtime, FileTime};
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // Three 100 KiB cache files; mtimes ascending so k1 is oldest. Total 300 KiB > 256 KiB cap.
+        let mk = |name: &str, secs: i64| {
+            let p = dir.join(name);
+            std::fs::write(&p, vec![0u8; 100 * 1024]).unwrap();
+            set_file_mtime(&p, FileTime::from_unix_time(secs, 0)).unwrap();
+            p
+        };
+        let p1 = mk("k1", 1000);
+        let p2 = mk("k2", 2000);
+        let p3 = mk("k3", 3000);
+
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let m = Arc::new(ObjectCacheMetrics::default());
+        let c = CachingObjectStore::new(inner, dir.to_path_buf(), 256 * 1024, u64::MAX, m);
+
+        let used = c.lru.lock().unwrap().used;
+        assert!(
+            used <= 256 * 1024,
+            "used {used} must be within the byte cap after scan"
+        );
+        assert!(used > 0, "some entries retained");
+        assert!(
+            !p1.exists(),
+            "oldest over-cap file must be evicted on startup"
+        );
+        assert!(p2.exists() && p3.exists(), "newer files retained");
+    }
+
+    #[tokio::test]
+    async fn versioned_reads_are_not_cached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let loc = OPath::from("ns/data/abc.lance");
+        inner
+            .put(&loc, PutPayload::from(vec![3u8; 4096]))
+            .await
+            .unwrap();
+        let (c, m) = cache(tmp.path(), inner);
+
+        // A versioned read resolves to different bytes than a plain (path, range) read, so it must
+        // pass through uncached. (InMemory may or may not honour `version`; we only assert routing.)
+        let opts = GetOptions {
+            version: Some("v1".into()),
+            ..Default::default()
+        };
+        let _ = c.get_opts(&loc, opts.clone()).await;
+        let _ = c.get_opts(&loc, opts).await;
+        let (inner_gets, hits, _, _, _) = m.snapshot();
+        assert_eq!(hits, 0, "versioned reads must never be cached");
+        assert_eq!(
+            inner_gets, 2,
+            "both versioned reads passed through to the inner store"
+        );
+    }
+}

--- a/crates/firnflow-core/tests/object_cache_s3_smoke.rs
+++ b/crates/firnflow-core/tests/object_cache_s3_smoke.rs
@@ -1,0 +1,248 @@
+//! Live object-cache smoke test (issue #51), S3-gated `#[ignore]`.
+//!
+//! Exercises the cache through Firn's real `NamespaceManager` + the session wiring
+//! (`with_object_cache_session`), against real object storage, and proves the three merge gates:
+//!   1. a repeated (warm) query issues fewer S3 GETs than its first (cold) execution, and produces
+//!      cache hits;
+//!   2. namespace delete + recreate serves the NEW data — cached bytes from the old table are never
+//!      served (manifests aren't cached; data/index are uniquely named);
+//!   3. cached payload on disk stays within the configured byte cap across a simulated restart.
+//!
+//! Runs against AWS S3 or any S3-compatible endpoint (e.g. MinIO). Against MinIO, set
+//! `FIRNFLOW_S3_ENDPOINT` (path-style + http are enabled automatically), mirroring the repo's
+//! other S3-gated tests.
+//!
+//! ```text
+//! # AWS S3
+//! FIRNFLOW_S3_BUCKET=<bucket> FIRNFLOW_S3_ACCESS_KEY=<id> FIRNFLOW_S3_SECRET_KEY=<secret> \
+//! FIRNFLOW_S3_REGION=eu-west-1 \
+//!   ./scripts/cargo test -p firnflow-core --test object_cache_s3_smoke -- --ignored --nocapture
+//!
+//! # MinIO (docker compose up -d minio minio-init)
+//! FIRNFLOW_S3_BUCKET=firnflow-test FIRNFLOW_S3_ACCESS_KEY=minioadmin \
+//! FIRNFLOW_S3_SECRET_KEY=minioadmin FIRNFLOW_S3_ENDPOINT=http://127.0.0.1:9000 \
+//!   ./scripts/cargo test -p firnflow-core --test object_cache_s3_smoke -- --ignored --nocapture
+//! ```
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::object_cache::{build_cached_session, ObjectCacheConfig, ObjectCacheMetrics};
+use firnflow_core::{NamespaceId, NamespaceManager, StorageRoot, UpsertRow};
+
+const DIM: usize = 128;
+const ROWS: u64 = 10_000;
+
+fn env(k: &str) -> String {
+    std::env::var(k).unwrap_or_else(|_| panic!("set {k} for the live smoke test"))
+}
+fn env_or(k: &str, d: &str) -> String {
+    std::env::var(k).unwrap_or_else(|_| d.to_string())
+}
+
+fn s3_options() -> HashMap<String, String> {
+    let mut o = HashMap::from([
+        ("aws_access_key_id".into(), env("FIRNFLOW_S3_ACCESS_KEY")),
+        (
+            "aws_secret_access_key".into(),
+            env("FIRNFLOW_S3_SECRET_KEY"),
+        ),
+        (
+            "aws_region".into(),
+            env_or("FIRNFLOW_S3_REGION", "eu-west-1"),
+        ),
+    ]);
+    // Optional S3-compatible endpoint (MinIO et al). When set, use path-style addressing over
+    // http, matching the repo's existing MinIO-gated tests. Absent → default AWS (virtual-hosted).
+    if let Ok(endpoint) = std::env::var("FIRNFLOW_S3_ENDPOINT") {
+        o.insert("aws_endpoint".into(), endpoint);
+        o.insert("allow_http".into(), "true".into());
+        o.insert("aws_virtual_hosted_style_request".into(), "false".into());
+    }
+    o
+}
+
+fn vec_for(seed: u64) -> Vec<f32> {
+    (0..DIM as u64)
+        .map(|i| ((seed.wrapping_mul(2_654_435_761).wrapping_add(i)) % 1000) as f32 / 1000.0)
+        .collect()
+}
+
+fn unique(prefix: &str) -> String {
+    let n = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{n}")
+}
+
+/// Bytes of cached object data on disk — the quantity the byte cap governs. Excludes the small
+/// `.sz` size sidecars and any in-flight `.tmp` files, which are auxiliary, not cached payload.
+fn payload_bytes(p: &Path) -> u64 {
+    let mut total = 0;
+    if let Ok(rd) = std::fs::read_dir(p) {
+        for e in rd.flatten() {
+            match e.metadata() {
+                Ok(m) if m.is_dir() => total += payload_bytes(&e.path()),
+                Ok(m) => {
+                    let name = e.file_name();
+                    let name = name.to_string_lossy();
+                    if !name.ends_with(".sz") && !name.ends_with(".tmp") {
+                        total += m.len();
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+    }
+    total
+}
+
+#[tokio::test]
+#[ignore]
+async fn object_cache_live_s3_gates() {
+    let bucket = env("FIRNFLOW_S3_BUCKET");
+    let opts = s3_options();
+    // TempDir removes the cache directory on drop, including on a panic during unwind.
+    let cache_dir = tempfile::tempdir().expect("temp cache dir");
+    let ns = NamespaceId::new(unique("objcache")).unwrap();
+
+    let result = run_gates(&bucket, &opts, cache_dir.path(), &ns).await;
+
+    // Always clean up the namespace in the bucket, pass or fail, before surfacing the outcome.
+    let _ = NamespaceManager::new(
+        StorageRoot::s3_bucket(&bucket).unwrap(),
+        s3_options(),
+        test_metrics(),
+    )
+    .delete(&ns)
+    .await;
+
+    result.expect("object-cache live S3 gates");
+    println!("ALL GATES PASSED");
+}
+
+async fn run_gates(
+    bucket: &str,
+    opts: &HashMap<String, String>,
+    cache_root: &Path,
+    ns: &NamespaceId,
+) -> Result<(), String> {
+    let root = || StorageRoot::s3_bucket(bucket).map_err(|e| e.to_string());
+
+    // ---------- gate 1: warm query drops S3 GETs ----------
+    let cfg = ObjectCacheConfig::new(cache_root.to_path_buf(), 5 * 1024 * 1024 * 1024);
+    let metrics = Arc::new(ObjectCacheMetrics::unregistered());
+    let session = build_cached_session(&cfg, metrics.clone());
+    let manager = NamespaceManager::new(root()?, opts.clone(), test_metrics())
+        .with_object_cache_session(session);
+
+    let rows: Vec<UpsertRow> = (0..ROWS).map(|i| (i, vec_for(i)).into()).collect();
+    manager
+        .upsert(ns, rows)
+        .await
+        .map_err(|e| format!("upsert: {e}"))?;
+
+    let q = vec_for(42);
+    let (g0, h0, ..) = metrics.snapshot();
+    let cold = manager
+        .query(ns, q.clone(), None, 10, None, None, false)
+        .await
+        .map_err(|e| format!("cold query: {e}"))?;
+    let (g1, h1, ..) = metrics.snapshot();
+    let warm = manager
+        .query(ns, q.clone(), None, 10, None, None, false)
+        .await
+        .map_err(|e| format!("warm query: {e}"))?;
+    let (g2, h2, ..) = metrics.snapshot();
+
+    let (cold_gets, warm_gets) = (g1 - g0, g2 - g1);
+    println!(
+        "GATE 1  cold_S3_GETs={cold_gets}  warm_S3_GETs={warm_gets}  cold_hits={}  warm_hits={}",
+        h1 - h0,
+        h2 - h1
+    );
+    if cold.results.len() != 10 {
+        return Err(format!(
+            "cold query returned {} results, want 10",
+            cold.results.len()
+        ));
+    }
+    if warm.results.len() != 10 {
+        return Err(format!(
+            "warm query returned {} results, want 10",
+            warm.results.len()
+        ));
+    }
+    if cold_gets == 0 {
+        return Err("cold query made no S3 GETs".into());
+    }
+    if warm_gets >= cold_gets {
+        return Err(format!(
+            "warm GETs {warm_gets} not fewer than cold {cold_gets}"
+        ));
+    }
+    if h2 <= h1 {
+        return Err("warm query produced no cache hits".into());
+    }
+
+    // ---------- gate 2: delete + recreate serves NEW data (no stale) ----------
+    manager
+        .delete(ns)
+        .await
+        .map_err(|e| format!("delete: {e}"))?;
+    let marker = 987_654_u64;
+    let mut mvec = vec![0.0_f32; DIM];
+    mvec[0] = 9.0; // far from the old normalized vectors
+    manager
+        .upsert(ns, vec![(marker, mvec.clone()).into()])
+        .await
+        .map_err(|e| format!("recreate upsert: {e}"))?;
+    let after = manager
+        .query(ns, mvec, None, 1, None, None, false)
+        .await
+        .map_err(|e| format!("post-recreate query: {e}"))?;
+    let top = after.results.first().map(|r| r.id);
+    println!("GATE 2  post-recreate top id={top:?}");
+    if top != Some(marker) {
+        return Err(format!(
+            "recreate served stale data: top id {top:?}, want {marker}"
+        ));
+    }
+
+    let payload_before = payload_bytes(cache_root);
+    drop(manager);
+    drop(metrics);
+
+    // ---------- gate 3: byte cap honoured across a simulated restart ----------
+    // Rebuild over the SAME cache dir with a tiny cap; opening the store on the next query triggers
+    // the per-store startup scan, which evicts cached payload down to the cap.
+    let small_cap = 1024 * 1024; // 1 MiB — below the gate-1 working set
+    let cfg2 = ObjectCacheConfig::new(cache_root.to_path_buf(), small_cap);
+    let session2 = build_cached_session(&cfg2, Arc::new(ObjectCacheMetrics::unregistered()));
+    let manager2 = NamespaceManager::new(root()?, opts.clone(), test_metrics())
+        .with_object_cache_session(session2);
+    manager2
+        .query(ns, vec_for(7), None, 1, None, None, false)
+        .await
+        .map_err(|e| format!("post-restart query: {e}"))?;
+    let payload_after = payload_bytes(cache_root);
+    println!(
+        "GATE 3  payload bytes before restart={payload_before}  after tiny-cap restart={payload_after}  (cap={small_cap})"
+    );
+    // The gate only proves eviction if the pre-restart set actually exceeded the cap.
+    if payload_before <= small_cap {
+        return Err(format!(
+            "gate 3 inconclusive: pre-restart payload {payload_before} did not exceed cap {small_cap}, so eviction was not exercised"
+        ));
+    }
+    if payload_after > small_cap {
+        return Err(format!(
+            "cached payload {payload_after} exceeds cap {small_cap} after restart"
+        ));
+    }
+
+    Ok(())
+}

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -129,6 +129,18 @@ handler</code></pre>
       </tbody>
     </table>
 
+    <h2>Object cache</h2>
+    <p>The result cache above answers a whole query from a single cached payload, so a repeated query reads nothing from object storage. It cannot help a query it has never seen &mdash; a new filter, a new vector, or the first query after a restart still falls through to the backend, where cold latency is dominated by object-storage reads. The object cache is an optional second layer that targets exactly those reads. It is disabled by default and enabled with <code>FIRNFLOW_OBJECT_CACHE_ENABLED</code>.</p>
+    <p>It sits one level below the storage engine: a local byte-range cache wrapped around the object store the engine reads through. When the engine asks for a range of a file, the cache serves it from local disk if present, otherwise fetches it from object storage and keeps a copy. The next query that touches the same data and index bytes &mdash; even a different query shape &mdash; is served locally.</p>
+
+    <h3>What it caches, and why that is safe</h3>
+    <p>Correctness rests on caching only objects that are immutable once written. Lance writes data fragments and index files under unique, write-once paths and never mutates them in place, so a cached byte range can never go stale: a later version is a different file with a different name. The cache restricts itself to those object classes.</p>
+    <p>Everything that <em>can</em> change is always read straight through, never cached: manifests, the version pointer, and transaction logs, plus any HEAD, conditional, or explicitly-versioned read. Because the manifest is always read live, a write, delete, compaction, or index build is observed immediately &mdash; the engine resolves the new manifest, which names new fragment and index files, and the cache simply misses on those new names and fetches them. A deleted-and-recreated namespace is safe for the same reason: it writes fresh unique paths, so old cached bytes are unreachable rather than served. There is no invalidation step because there is nothing mutable to invalidate.</p>
+
+    <h3>Capacity and restart</h3>
+    <p>The cache is bounded by a byte budget (<code>FIRNFLOW_OBJECT_CACHE_BYTES</code>); when full it evicts least-recently-used entries. On startup it scans its directory and counts existing files toward the budget, evicting down to the cap before serving, so a restart reuses the warm cache without exceeding its bound. Like every cache here it is a performance layer only &mdash; object storage remains the source of truth, and losing the local cache costs latency, never data.</p>
+    <p>Effectiveness and savings are observable through the <a href="monitoring.html">object-cache metrics</a> (<code>firnflow_object_cache_hits_total</code>, <code>_misses_total</code>, <code>_s3_bytes_total</code>, <code>_evictions_total</code>).</p>
+
     <h2>Connection pool</h2>
     <p>The namespace manager caches a <code>lancedb::Connection</code> and <code>Table</code> handle per namespace after the first open. Without the pool, every upsert and every cache-miss query would re-run credential resolution (AWS chain or Google service-account JSON, depending on backend) and re-read the Lance table manifest; with the pool, those costs are paid once per namespace per process lifetime.</p>
 

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -221,6 +221,41 @@ GOOGLE_APPLICATION_CREDENTIALS=/etc/firnflow/gcp-sa.json</code></pre>
       The cache is a performance optimisation, not durable storage. Data in the configured object store is always the source of truth. If the cache is lost (restart, crash, disk failure), Firn repopulates it transparently on the next query.
     </div>
 
+    <h2 id="object-cache">Object cache</h2>
+    <p>The object cache is a separate, optional layer from the result cache above. It is a local byte-range cache that sits <em>under</em> the storage engine: on a cache miss the engine still reads the namespace's data and index files from object storage, but those reads are served from local disk on subsequent queries. It accelerates cold and novel queries (different filters, new vectors) that the result cache cannot help, because they never hit object storage twice for the same bytes.</p>
+    <p>It only caches immutable, uniquely-named objects (data fragments and index files, which are written once and never mutated). Manifests, version pointers, and transaction logs are always read straight through, so a write, delete, compaction, or index build is reflected immediately &mdash; the cache cannot serve stale data. It is disabled by default.</p>
+
+    <table>
+      <thead><tr><th>Variable</th><th>Default</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><code>FIRNFLOW_OBJECT_CACHE_ENABLED</code></td>
+          <td><code>false</code></td>
+          <td>Enable the byte-range object cache. When off, every object-storage read goes straight to the backend.</td>
+        </tr>
+        <tr>
+          <td><code>FIRNFLOW_OBJECT_CACHE_DIR</code></td>
+          <td><code>/tmp/firnflow-object-cache</code></td>
+          <td>Directory for cached object bytes. In production, point this at a fast local SSD/NVMe. Existing files are scanned and counted toward the capacity on startup, so the cache survives a restart within its byte budget.</td>
+        </tr>
+        <tr>
+          <td><code>FIRNFLOW_OBJECT_CACHE_BYTES</code></td>
+          <td><code>10737418240</code> (10 GB)</td>
+          <td>Maximum bytes of cached object data held on disk. When full, least-recently-used entries are evicted. The cap is enforced across restarts (small per-entry size sidecars are negligible additional overhead).</td>
+        </tr>
+        <tr>
+          <td><code>FIRNFLOW_OBJECT_CACHE_MAX_ENTRY_BYTES</code></td>
+          <td><code>268435456</code> (256 MB)</td>
+          <td>Largest single read the cache will buffer and store. A read above this is streamed straight through and not cached, so one large fragment read cannot spike memory by its full size. Lower it on memory-constrained hosts; raise it to cache larger fragments whole.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="callout callout-info">
+      <div class="callout-title">Result cache vs object cache</div>
+      The result cache stores whole query results and turns a repeated query into zero object-storage reads. The object cache stores raw file byte ranges and makes the <em>first</em> execution of a new query cheaper the next time similar data is read. They are complementary and can be enabled together.
+    </div>
+
     <h2>Authentication</h2>
     <p>Firn supports optional bearer-token authentication. Both keys are opt-in via env: when neither is set, the API stays open and logs a single startup <code>WARN</code> (the default for the local-dev compose stack).</p>
 

--- a/docs/monitoring.html
+++ b/docs/monitoring.html
@@ -166,6 +166,44 @@ scrape_configs:
       <code>firnflow_s3_requests_total</code> is the metric that proves backend work happened. For exact-cache-only traffic, compare <code>s3_requests_total{operation="query"}</code> against <code>cache_misses_total</code>; they should be equal. For semantic-cache traffic, semantic hits make <code>s3_requests_total{operation="query"}</code> lower than exact-cache misses. (The metric name is historical and kept stable for dashboard continuity; it counts requests against any configured backend.)
     </div>
 
+    <h3>Object cache metrics</h3>
+    <p>These track the optional byte-range <a href="configuration.html#object-cache">object cache</a>. They are global rather than per-namespace, because the cache operates at the object-store layer beneath the namespace abstraction and has no namespace label. They are always registered and read <code>0</code> when the object cache is disabled.</p>
+    <table>
+      <thead><tr><th>Metric</th><th>Type</th><th>Labels</th><th>Description</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><code>firnflow_object_cache_hits_total</code></td>
+          <td>Counter</td>
+          <td><em>none</em></td>
+          <td>Byte-range reads served from the local object cache without an object-storage round-trip. The primary effectiveness signal for cold and novel queries.</td>
+        </tr>
+        <tr>
+          <td><code>firnflow_object_cache_misses_total</code></td>
+          <td>Counter</td>
+          <td><em>none</em></td>
+          <td>Cacheable reads that missed, were fetched from object storage, and were then written to the local cache.</td>
+        </tr>
+        <tr>
+          <td><code>firnflow_object_cache_inner_gets_total</code></td>
+          <td>Counter</td>
+          <td><em>none</em></td>
+          <td>Reads forwarded to object storage: misses plus uncacheable passthroughs (manifests, version pointers, and HEAD / conditional / versioned reads, which are never cached).</td>
+        </tr>
+        <tr>
+          <td><code>firnflow_object_cache_s3_bytes_total</code></td>
+          <td>Counter</td>
+          <td><em>none</em></td>
+          <td>Total bytes fetched from object storage by the cache on misses. A proxy for egress and request-size cost avoided on subsequent hits.</td>
+        </tr>
+        <tr>
+          <td><code>firnflow_object_cache_evictions_total</code></td>
+          <td>Counter</td>
+          <td><em>none</em></td>
+          <td>Entries evicted from the local cache to stay within <code>FIRNFLOW_OBJECT_CACHE_BYTES</code>. A high rate relative to hits suggests the byte cap is too small for the working set.</td>
+        </tr>
+      </tbody>
+    </table>
+
     <h3>Auth and rate-limit metrics</h3>
     <table>
       <thead><tr><th>Metric</th><th>Type</th><th>Labels</th><th>Description</th></tr></thead>
@@ -213,6 +251,15 @@ histogram_quantile(0.99, rate(firnflow_query_duration_seconds_bucket[5m]))</code
 
     <h3>Object-storage requests saved (total avoided queries)</h3>
     <pre><code>sum(firnflow_cache_hits_total) + sum(firnflow_semantic_cache_hits_total)</code></pre>
+
+    <h3>Object-cache hit rate</h3>
+    <p>The fraction of cacheable byte-range reads served from the local object cache:</p>
+    <pre><code>sum(rate(firnflow_object_cache_hits_total[5m]))
+/
+(sum(rate(firnflow_object_cache_hits_total[5m])) + sum(rate(firnflow_object_cache_misses_total[5m])))</code></pre>
+
+    <h3>Object-storage bytes fetched by the object cache</h3>
+    <pre><code>rate(firnflow_object_cache_s3_bytes_total[5m])</code></pre>
     <p>Each exact-cache hit and semantic-cache hit is one object-storage query that did not happen. Semantic-cache hits are approximate result reuse, so track them separately when correctness calibration matters.</p>
 
     <h3>Semantic-cache hit rate (eligible lookups)</h3>


### PR DESCRIPTION
Closes #51.

## What and why

Firn's result cache only helps exact repeated queries. Profiling against real in-region S3 showed that cold and novel queries spend almost all of their time on object-storage reads: a cold vector-index query issues on the order of 140 small GETs, mostly index files, and is bound by request count rather than bytes. The result cache cannot help there, because the query is not an exact repeat.

This adds a read-through cache that sits under the storage engine and keeps the byte ranges Lance reads from object storage on local disk. A repeated or non-identical query over the same data is served from local NVMe instead of paying the S3 round-trips. It is off by default.

## How it hooks in

Lance reads through `object_store::ObjectStore`. The cache wraps that store via a custom object-store provider registered on a Lance session, which is passed to the connection. No fork of Lance or LanceDB is needed.

## Correctness

Only immutable, write-once objects are cached: data fragments and index files, which are uniquely named and never mutated. Manifests, version pointers, transaction logs, and any HEAD, conditional, or versioned read are always read straight through and never cached. So a write, delete, compaction, or index build is not hidden by the object cache, and a deleted-then-recreated namespace writes new unique paths whose old cached bytes are unreferenced rather than served. There is no separate invalidation step; eviction is purely for capacity.

Disk usage is bounded by a byte budget with LRU eviction, enforced across restarts by scanning the cache directory on startup. A single read larger than the per-entry limit is streamed straight through rather than buffered, so one large fragment read cannot spike memory.

## Operational scope

This is a local per-process cache, not a distributed cache and not a durability layer. Object storage remains the source of truth; deleting the cache only costs warmup latency. Eviction is global for the configured object-cache directory, not per namespace.

## Configuration

| Variable | Default | Purpose |
| --- | --- | --- |
| `FIRNFLOW_OBJECT_CACHE_ENABLED` | `false` | Turn the cache on |
| `FIRNFLOW_OBJECT_CACHE_DIR` | `/tmp/firnflow-object-cache` | Where cached bytes live (point at fast local NVMe) |
| `FIRNFLOW_OBJECT_CACHE_BYTES` | 10 GB | On-disk byte budget (LRU eviction) |
| `FIRNFLOW_OBJECT_CACHE_MAX_ENTRY_BYTES` | 256 MB | Largest single read to buffer and cache |

## Metrics

Five counters at `/metrics` for object-cache hit rate, backend reads, fetched bytes, and evictions: `firnflow_object_cache_hits_total`, `firnflow_object_cache_misses_total`, `firnflow_object_cache_inner_gets_total`, `firnflow_object_cache_s3_bytes_total`, `firnflow_object_cache_evictions_total`. Global rather than per-namespace, since the cache sits below the namespace layer.

## Testing

Unit tests cover the cache behaviour: immutable caching, metadata passthrough, HEAD and versioned reads, capacity eviction, the startup scan, the per-entry and over-capacity limits, the size sidecar, and metrics registration.

The live S3 smoke test is `crates/firnflow-core/tests/object_cache_s3_smoke.rs`, gated behind `ignore` and run explicitly with `cargo test -p firnflow-core --test object_cache_s3_smoke -- --ignored --nocapture` (it needs S3 or MinIO credentials in the environment). Run through the namespace manager against real object storage, it proves the three things that matter:

- a warm query drops from 6 backend GETs to 0, with cache hits recorded;
- a delete and recreate serves the new data, never stale cached bytes;
- the byte cap holds across a restart (5.2 MB of cached payload evicted down to under a 1 MB cap).

The non-ignored suite is green: `cargo test --workspace` passes, including 75 firnflow-core library tests (the object-cache unit tests among them) and 34 firnflow-api library tests, plus the offline integration tests. `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` are both clean.

Configuration, monitoring, and architecture docs under `docs/` are updated.
