### PR TITLE
Honour AWS_REGION and AWS_DEFAULT_REGION for S3 region resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- S3 region resolution now honours the standard `AWS_REGION` and `AWS_DEFAULT_REGION` environment variables. Previously the region was read only from `FIRNFLOW_S3_REGION` and defaulted to `us-east-1` when that was unset, silently ignoring the `AWS_*` variables a host already exports — so a deployment in, say, `eu-west-1` that set `AWS_REGION` the conventional way still talked to `us-east-1` and failed against any backend that enforces region. Resolution order is now `FIRNFLOW_S3_REGION`, then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the `us-east-1` fallback (matching the AWS SDK's own `AWS_REGION`-over-`AWS_DEFAULT_REGION` precedence). Set `FIRNFLOW_S3_REGION` to pin the region explicitly; otherwise the ambient AWS region is picked up automatically. The same fix applies to the benchmark harnesses, which shared the old default.
+
 ## [0.9.0] - 2026-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ FIRNFLOW_S3_REGION=eu-west-1
 # AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, ~/.aws/credentials).
 ```
 
+`FIRNFLOW_S3_REGION` is optional: if it is unset, Firn falls back to the standard `AWS_REGION`, then `AWS_DEFAULT_REGION`, and only then to `us-east-1`. Set `FIRNFLOW_S3_REGION` to pin the region for Firn explicitly, or rely on the `AWS_*` variables your host already exports (the usual case on EC2/ECS). A region that does not match the bucket's region fails the request, so this matters for any backend that enforces region (real AWS S3 does; MinIO and most emulators ignore it).
+
 ### MinIO (local / self-hosted)
 
 ```bash

--- a/crates/firnflow-api/src/config.rs
+++ b/crates/firnflow-api/src/config.rs
@@ -352,9 +352,16 @@ fn build_s3_storage_options() -> HashMap<String, String> {
     if let Ok(v) = std::env::var("FIRNFLOW_S3_SECRET_KEY") {
         opts.insert("aws_secret_access_key".into(), v);
     }
+    // Region resolution honours FIRNFLOW_S3_REGION, then the standard
+    // AWS_REGION / AWS_DEFAULT_REGION variables, then a us-east-1
+    // fallback. Setting it unconditionally here is deliberate: the
+    // value is fed to lancedb's connection builder and to the
+    // delete-path object_store builder, and an explicit region must
+    // win over the bare AmazonS3Builder::from_env() default in the
+    // latter. See firnflow_core::resolve_s3_region for the precedence.
     opts.insert(
         "aws_region".into(),
-        env_or("FIRNFLOW_S3_REGION", "us-east-1"),
+        firnflow_core::resolve_s3_region(|k| std::env::var(k).ok()),
     );
     opts
 }

--- a/crates/firnflow-bench/src/bin/first_query_profile.rs
+++ b/crates/firnflow-bench/src/bin/first_query_profile.rs
@@ -65,7 +65,7 @@
 //! | `FIRNFLOW_S3_ENDPOINT`             | (real AWS)                             |
 //! | `FIRNFLOW_S3_ACCESS_KEY`           | (default credential chain)             |
 //! | `FIRNFLOW_S3_SECRET_KEY`           | (default credential chain)             |
-//! | `FIRNFLOW_S3_REGION`               | `us-east-1`                            |
+//! | `FIRNFLOW_S3_REGION`               | `AWS_REGION` / `AWS_DEFAULT_REGION`, else `us-east-1` |
 //! | `FIRNFLOW_PROFILE_NAMESPACE`       | `first-query-profile`                  |
 //! | `FIRNFLOW_PROFILE_SEED`            | `true`                                 |
 //! | `FIRNFLOW_PROFILE_ROWS`            | `100000`                               |
@@ -187,7 +187,7 @@ impl Config {
         }
         opts.insert(
             "aws_region".into(),
-            env_or("FIRNFLOW_S3_REGION", "us-east-1"),
+            firnflow_core::resolve_s3_region(|k| std::env::var(k).ok()),
         );
 
         let backend_label = std::env::var("FIRNFLOW_PROFILE_BACKEND_LABEL")

--- a/crates/firnflow-bench/src/bin/semantic_cache_profile.rs
+++ b/crates/firnflow-bench/src/bin/semantic_cache_profile.rs
@@ -110,7 +110,7 @@ impl BenchConfig {
         }
         opts.insert(
             "aws_region".into(),
-            env_or("FIRNFLOW_S3_REGION", "us-east-1"),
+            firnflow_core::resolve_s3_region(|k| std::env::var(k).ok()),
         );
 
         Ok(Self {

--- a/crates/firnflow-bench/src/main.rs
+++ b/crates/firnflow-bench/src/main.rs
@@ -40,7 +40,7 @@
 //! | `FIRNFLOW_S3_ENDPOINT`          | (real AWS)                                 |
 //! | `FIRNFLOW_S3_ACCESS_KEY`        | (default credential chain)                 |
 //! | `FIRNFLOW_S3_SECRET_KEY`        | (default credential chain)                 |
-//! | `FIRNFLOW_S3_REGION`            | `us-east-1`                                |
+//! | `FIRNFLOW_S3_REGION`            | `AWS_REGION` / `AWS_DEFAULT_REGION`, else `us-east-1` |
 //! | `FIRNFLOW_BENCH_DIM`            | `32`                                       |
 //! | `FIRNFLOW_BENCH_ROWS`           | `100`                                      |
 //! | `FIRNFLOW_BENCH_QUERIES`        | `50`                                       |
@@ -159,7 +159,7 @@ impl BenchConfig {
         }
         opts.insert(
             "aws_region".into(),
-            env_or("FIRNFLOW_S3_REGION", "us-east-1"),
+            firnflow_core::resolve_s3_region(|k| std::env::var(k).ok()),
         );
 
         Ok(Self {

--- a/crates/firnflow-core/src/lib.rs
+++ b/crates/firnflow-core/src/lib.rs
@@ -31,5 +31,5 @@ pub use query::{
 };
 pub use result::{ListOrder, ListPage, ListRow, NamespaceInfo, QueryResult, QueryResultSet};
 pub use service::{NamespaceService, QueryCacheSource, QueryOutcome};
-pub use storage_root::{Scheme, StorageRoot};
+pub use storage_root::{resolve_s3_region, Scheme, StorageRoot};
 pub use vector::VectorKind;

--- a/crates/firnflow-core/src/storage_root.rs
+++ b/crates/firnflow-core/src/storage_root.rs
@@ -301,12 +301,110 @@ fn absolute_utf8_dir(dir: &Path) -> Result<String, FirnflowError> {
     })
 }
 
+/// Resolve the S3 region from the environment, honouring firnflow's
+/// explicit override first and then the standard AWS SDK variables.
+///
+/// Precedence, highest first:
+///
+/// 1. `FIRNFLOW_S3_REGION` — the explicit firnflow knob, so an
+///    operator can pin the region for Firn without disturbing the
+///    ambient AWS region the rest of a host's tooling reads.
+/// 2. `AWS_REGION` — the standard AWS SDK variable.
+/// 3. `AWS_DEFAULT_REGION` — the SDK's lower-priority fallback.
+/// 4. `us-east-1` — a final default. It is a no-op for MinIO and
+///    other emulators (which ignore the region) but is still set
+///    because `object_store`'s S3 builder expects a region.
+///
+/// The `AWS_REGION`-over-`AWS_DEFAULT_REGION` order matches the AWS
+/// SDK's own resolution, so a host configured the conventional way —
+/// the case on EC2/ECS, where `AWS_REGION` is exported by the
+/// environment — works without an extra firnflow-specific variable.
+/// Empty or whitespace-only values are skipped, so an accidental
+/// `AWS_REGION=` export does not shadow a lower-priority source.
+///
+/// `get` looks a variable up by name; production callers pass
+/// `|k| std::env::var(k).ok()`. Threading the lookup through a
+/// closure keeps the precedence logic pure and unit-testable without
+/// mutating process-global environment state.
+pub fn resolve_s3_region(get: impl Fn(&str) -> Option<String>) -> String {
+    for key in ["FIRNFLOW_S3_REGION", "AWS_REGION", "AWS_DEFAULT_REGION"] {
+        if let Some(value) = get(key) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    "us-east-1".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     fn ns(name: &str) -> NamespaceId {
         NamespaceId::new(name).unwrap()
+    }
+
+    /// Build an env lookup closure backed by a fixed map, so the
+    /// region-precedence tests never touch process-global env state.
+    fn env_lookup(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    #[test]
+    fn region_defaults_to_us_east_1_when_nothing_set() {
+        assert_eq!(resolve_s3_region(env_lookup(&[])), "us-east-1");
+    }
+
+    #[test]
+    fn region_reads_aws_region_when_firnflow_unset() {
+        let env = env_lookup(&[("AWS_REGION", "eu-west-1")]);
+        assert_eq!(resolve_s3_region(env), "eu-west-1");
+    }
+
+    #[test]
+    fn region_reads_aws_default_region_as_lowest_aws_fallback() {
+        let env = env_lookup(&[("AWS_DEFAULT_REGION", "ap-southeast-2")]);
+        assert_eq!(resolve_s3_region(env), "ap-southeast-2");
+    }
+
+    #[test]
+    fn aws_region_wins_over_aws_default_region() {
+        let env = env_lookup(&[
+            ("AWS_REGION", "eu-west-1"),
+            ("AWS_DEFAULT_REGION", "us-west-2"),
+        ]);
+        assert_eq!(resolve_s3_region(env), "eu-west-1");
+    }
+
+    #[test]
+    fn firnflow_var_overrides_both_aws_vars() {
+        let env = env_lookup(&[
+            ("FIRNFLOW_S3_REGION", "eu-central-1"),
+            ("AWS_REGION", "eu-west-1"),
+            ("AWS_DEFAULT_REGION", "us-west-2"),
+        ]);
+        assert_eq!(resolve_s3_region(env), "eu-central-1");
+    }
+
+    #[test]
+    fn empty_value_does_not_shadow_lower_priority_source() {
+        // An exported-but-empty FIRNFLOW_S3_REGION must fall through
+        // to AWS_REGION rather than collapsing to the us-east-1 default.
+        let env = env_lookup(&[("FIRNFLOW_S3_REGION", "  "), ("AWS_REGION", "eu-west-1")]);
+        assert_eq!(resolve_s3_region(env), "eu-west-1");
+    }
+
+    #[test]
+    fn region_value_is_trimmed() {
+        let env = env_lookup(&[("AWS_REGION", " eu-west-1 ")]);
+        assert_eq!(resolve_s3_region(env), "eu-west-1");
     }
 
     #[test]

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -85,7 +85,7 @@
     <p>For S3-family backends, the <code>FIRNFLOW_S3_*</code> variables below configure the endpoint and credentials. For native Google Cloud Storage, set <code>FIRNFLOW_STORAGE_URI=gs://&lt;bucket&gt;</code> and one of the standard <code>GOOGLE_*</code> credential variables — no other firnflow-specific configuration is required.</p>
 
     <h3>S3-family variables</h3>
-    <p>For real AWS S3, you typically only need <code>FIRNFLOW_STORAGE_URI</code> and <code>FIRNFLOW_S3_REGION</code>. Credentials come from the standard AWS chain (instance profile, environment, <code>~/.aws/credentials</code>).</p>
+    <p>For real AWS S3, you typically only need <code>FIRNFLOW_STORAGE_URI</code>. Credentials come from the standard AWS chain (instance profile, environment, <code>~/.aws/credentials</code>), and the region follows <code>AWS_REGION</code> / <code>AWS_DEFAULT_REGION</code> if you do not set <code>FIRNFLOW_S3_REGION</code> explicitly.</p>
 
     <table>
       <thead><tr><th>Variable</th><th>Default</th><th>Description</th></tr></thead>
@@ -107,8 +107,8 @@
         </tr>
         <tr>
           <td><code>FIRNFLOW_S3_REGION</code></td>
-          <td><code>us-east-1</code></td>
-          <td>Region for the bucket. Some S3-compatible providers (R2, Tigris) accept <code>auto</code>.</td>
+          <td><code>AWS_REGION</code> / <code>AWS_DEFAULT_REGION</code>, else <code>us-east-1</code></td>
+          <td>Region for the bucket. If unset, Firn falls back to the standard <code>AWS_REGION</code>, then <code>AWS_DEFAULT_REGION</code>, then <code>us-east-1</code>. Set it to pin the region explicitly. Some S3-compatible providers (R2, Tigris) accept <code>auto</code>. A region that does not match the bucket fails the request on backends that enforce region (real AWS S3); MinIO and most emulators ignore it.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary

S3 region resolution read only `FIRNFLOW_S3_REGION` and defaulted to `us-east-1` when it was unset, ignoring the standard `AWS_REGION` / `AWS_DEFAULT_REGION` variables a host already exports. The delete path built its `object_store` client with `AmazonS3Builder::from_env()` — which would have read `AWS_REGION` — but the explicit `us-east-1` from the storage-options map then overrode it, so a deployment in `eu-west-1` that set `AWS_REGION` the conventional way still talked to `us-east-1` and failed against any backend that enforces region.

This adds a `firnflow_core::resolve_s3_region` helper with the precedence `FIRNFLOW_S3_REGION`, then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then a `us-east-1` fallback — matching the AWS SDK's own `AWS_REGION`-over-`AWS_DEFAULT_REGION` order — and wires it into the API config and the three benchmark harnesses that shared the old default.

## Behavior notes

- Setting `FIRNFLOW_S3_REGION` still pins the region explicitly and takes priority over everything else, so deployments that already set it are unaffected.
- With `FIRNFLOW_S3_REGION` unset, the region now follows `AWS_REGION`, then `AWS_DEFAULT_REGION`, before the `us-east-1` fallback. The fallback stays because `object_store`'s S3 builder expects a region set, and it is a no-op for MinIO and most emulators, which ignore region.
- Empty or whitespace-only values are skipped, so an exported-but-empty `AWS_REGION=` does not shadow a lower-priority source.
- The resolved region flows to both the lancedb connection and the delete-path `object_store` client through the same storage-options map, so the read/write and delete paths agree on one region.
- The Python package is unaffected: it only sets `aws_region` when a `region` argument is passed, otherwise letting the client read the AWS environment.
- README, `docs/configuration.html`, and the benchmark env-var tables now document the fallback; the CHANGELOG carries a `Fixed` entry under `[Unreleased]`.

## Tests

~~~text
./scripts/cargo fmt --all -- --check                                       # clean
./scripts/cargo check  -p firnflow-core  -j 1                              # clean
./scripts/cargo check  -p firnflow-api   -j 1                              # clean
./scripts/cargo check  -p firnflow-bench -j 1                              # clean
./scripts/cargo test   -p firnflow-core --lib storage_root::tests -j 1     # 39 passed (7 new region tests)
./scripts/cargo clippy -p firnflow-core  --all-targets -j 1 -- -D warnings # clean
./scripts/cargo clippy -p firnflow-api   --all-targets -j 1 -- -D warnings # clean
./scripts/cargo clippy -p firnflow-bench --all-targets -j 1 -- -D warnings # clean

cargo clippy --workspace --all-targets and cargo test --workspace were deliberately not run on this branch — the parallel link of every workspace and integration-test binary against Lance is too heavy for this 16 GB dev host. The three touched crates are linted individually with -D warnings, and the change is additive to firnflow-core's public surface, so the workspace-wide gate is left to CI.
~~~
