### PR TITLE
Auto-build id scalar index for upsert merge performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `POST /ns/{namespace}/scalar-index` takes an optional JSON body to choose which column to index. `{"column": "id"}` builds a BTree on the row id, and a request with no body keeps the previous default of `_ingested_at`. The `id` index is the maintenance path for namespaces created before auto-indexing existed (see Changed), so an operator can add it to an existing namespace without recreating it. An unsupported column is rejected with `400` before any background work starts. Closes #66.
+
+### Changed
+- `/upsert` builds a BTree index on `id` automatically on a namespace's first write. `/upsert` finds matches by `id` through LanceDB merge-insert; without an index on `id`, every batch scans each data fragment to decide which incoming ids are updates and which are inserts, so write latency climbed as a namespace grew. This was most visible on a large S3-backed first load, where per-batch commit and fragment work compounds the scan cost. Building the index once on the first write, while the table is still small, lets the merge-insert match lookup use the index instead of a full scan. The build is best-effort: the rows are committed first, so if the index build fails the upsert still succeeds and the index can be rebuilt later through `/scalar-index`. This does not by itself flatten throughput on a long append-heavy load, because rows written after the build land in unindexed fragments until a `/compact` folds them in; the recommended large-ingest path (load, compact, build indexes, query) is documented in the README. Refs #77.
+
 ### Fixed
 - S3 region resolution now honours the standard `AWS_REGION` and `AWS_DEFAULT_REGION` environment variables. Previously the region was read only from `FIRNFLOW_S3_REGION` and defaulted to `us-east-1` when that was unset, silently ignoring the `AWS_*` variables a host already exports — so a deployment in, say, `eu-west-1` that set `AWS_REGION` the conventional way still talked to `us-east-1` and failed against any backend that enforces region. Resolution order is now `FIRNFLOW_S3_REGION`, then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the `us-east-1` fallback (matching the AWS SDK's own `AWS_REGION`-over-`AWS_DEFAULT_REGION` precedence). Set `FIRNFLOW_S3_REGION` to pin the region explicitly; otherwise the ambient AWS region is picked up automatically. The same fix applies to the benchmark harnesses, which shared the old default.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ curl -X POST http://localhost:3000/ns/demo/upsert \
      }'
 ```
 
-Upsert is keyed by `id` and is latest-write-wins: re-sending a row whose `id` already exists replaces the stored row in full rather than adding a second copy, so retries and genuine updates are both safe. Ids must be unique within a single request. The `_ingested_at` timestamp tracks the most recent write to a row, not its first insert.
+Upsert is keyed by `id` and is latest-write-wins: re-sending a row whose `id` already exists replaces the stored row in full rather than adding a second copy, so retries and genuine updates are both safe. Ids must be unique within a single request. The `_ingested_at` timestamp tracks the most recent write to a row, not its first insert. The first write to a namespace builds a BTree index on `id` so later batches find their matches through the index instead of scanning every data file. See [Loading data at scale](#loading-data-at-scale) for first-load guidance.
 
 ### 3. Perform a Search
 Query the same namespace for the nearest neighbor:
@@ -254,13 +254,33 @@ If `FIRNFLOW_ADMIN_API_KEY` is unset, the read/write key authorises admin routes
 | `/ns/{ns}/warmup` | `POST` | read/write | Non-blocking cache pre-warm hint |
 | `/ns/{ns}/index` | `POST` | admin | Build IVF_PQ vector index (async, returns 202) |
 | `/ns/{ns}/fts-index` | `POST` | admin | Build BM25 full-text search index (async, returns 202) |
-| `/ns/{ns}/scalar-index` | `POST` | admin | Build BTree index on `_ingested_at` to accelerate `/list` (async, returns 202) |
+| `/ns/{ns}/scalar-index` | `POST` | admin | Build a BTree index on a column (async, returns 202). Optional body `{"column": "id"}` for write-path merge-insert lookups; defaults to `_ingested_at` to accelerate `/list` |
 | `/ns/{ns}/compact` | `POST` | admin | Compact and prune data files (async, returns 202) |
 | `/operations/{id}` | `GET` | read/write | Status of a background operation by the `operation_id` from its 202; 404 if unknown or evicted |
 
 The async endpoints (`warmup`, `index`, `fts-index`, `scalar-index`, `compact`) return an opaque `operation_id` in their `202`; poll `GET /operations/{id}` to see whether the work is `running`, `succeeded`, or `failed` instead of inferring it from metrics.
 
 Auth column: `open` = no header required; `read/write` = `FIRNFLOW_API_KEY` (or `FIRNFLOW_ADMIN_API_KEY`); `admin` = `FIRNFLOW_ADMIN_API_KEY` if configured, otherwise `FIRNFLOW_API_KEY` via the single-key fallback. `/metrics` is `metrics` when `FIRNFLOW_METRICS_TOKEN` is set, otherwise `open`.
+
+## Loading data at scale
+
+Two ingest shapes have different cost profiles, and it helps to treat them differently.
+
+**Idempotent updates** (retries, re-ingesting changed documents) are what `/upsert` is built for. It is keyed by `id` and latest-write-wins, so re-sending a row is safe. The first write to a namespace builds a BTree on `id`, which is what the per-batch merge-insert uses to find existing rows instead of scanning every data file.
+
+**A large first load** (millions of rows into a fresh namespace over S3) needs a bit more care. Every `/upsert` is a separate commit, so a long run of small batches produces many small data files, and the per-commit and per-file bookkeeping adds up. Two things keep throughput steady:
+
+- **Use larger batches.** Fewer, bigger commits beat many tiny ones. The body limit is `FIRNFLOW_MAX_BODY_BYTES` (default 16 MB), so size batches up toward that rather than sending rows a handful at a time.
+- **Build indexes after the bulk load, not during it.** Index builds are most efficient over settled data.
+
+A recommended recipe for a first load:
+
+1. **Load** the data in large `/upsert` batches.
+2. **Compact** once the load is done: `POST /ns/{ns}/compact`. This merges the many small data files into fewer large ones and folds freshly written rows into the existing `id` index.
+3. **Build the query indexes**: `POST /ns/{ns}/index` (vector), `POST /ns/{ns}/fts-index` (full-text), and `POST /ns/{ns}/scalar-index` with `{"column": "_ingested_at"}` if you page with `/list`. These are async; poll `GET /operations/{id}`.
+4. **Query.**
+
+For a namespace created before auto-indexing existed, build the `id` index once with `POST /ns/{ns}/scalar-index -d '{"column": "id"}'` to get the same write-path benefit.
 
 ## Multivector namespaces
 

--- a/crates/firnflow-api/src/handlers.rs
+++ b/crates/firnflow-api/src/handlers.rs
@@ -42,6 +42,22 @@ pub struct DeleteResponse {
     pub objects_deleted: usize,
 }
 
+/// Optional body of `POST /ns/{namespace}/scalar-index`. Selects the
+/// column to build the BTree on; omitting the body (or the field)
+/// keeps the historical default of `_ingested_at`.
+#[derive(Debug, Deserialize)]
+pub struct ScalarIndexRequest {
+    /// Column to index: `id` (write-path merge-insert lookups) or
+    /// `_ingested_at` (the `/list` ordering column). Defaults to
+    /// `_ingested_at`.
+    #[serde(default = "default_scalar_index_column")]
+    pub column: String,
+}
+
+fn default_scalar_index_column() -> String {
+    "_ingested_at".to_string()
+}
+
 /// Body of `POST /ns/{namespace}/warmup`. A list of query
 /// parameters the operator wants pre-populated in the cache.
 #[derive(Debug, Deserialize)]
@@ -379,19 +395,31 @@ pub async fn create_fts_index(
     ))
 }
 
-/// Build a BTree scalar index on `_ingested_at`. Same
+/// Build a BTree scalar index on a namespace column. Same
 /// 202-with-`operation_id` pattern as `/fts-index`; poll
 /// `GET /operations/{operation_id}` for completion, or watch
 /// `firnflow_index_build_duration_seconds{kind="scalar"}`.
 ///
-/// v1 hardcodes the column to `_ingested_at` to mirror the same
-/// constraint `/list` puts on `order_by`. Future user-column ordering
-/// adds a body parameter at that point.
+/// The column comes from an optional JSON body
+/// (`{"column": "id"}`); with no body it defaults to `_ingested_at`,
+/// preserving the original no-body behaviour. Valid columns are `id`
+/// (write-path merge-insert lookups — the maintenance path for
+/// namespaces created before auto-indexing) and `_ingested_at` (the
+/// `/list` ordering column). An unsupported column is rejected with
+/// a synchronous `400` before any background work starts.
 pub async fn create_scalar_index(
     State(state): State<AppState>,
     Path(namespace): Path<String>,
+    body: Option<Json<ScalarIndexRequest>>,
 ) -> Result<(StatusCode, Json<OperationAccepted>), ApiError> {
     let ns = NamespaceId::new(namespace)?;
+    let column = body
+        .map(|Json(req)| req.column)
+        .unwrap_or_else(default_scalar_index_column);
+
+    // Reject an unsupported column up front so the caller gets a 400
+    // rather than a 202 followed by a log-only background failure.
+    firnflow_core::validate_scalar_index_column(&column).map_err(ApiError::Core)?;
 
     let operation_id = state
         .operations
@@ -402,7 +430,7 @@ pub async fn create_scalar_index(
     let ns_owned = ns.clone();
     let op_for_task = operation_id.clone();
     tokio::spawn(async move {
-        match service.create_scalar_index(&ns_owned, "_ingested_at").await {
+        match service.create_scalar_index(&ns_owned, &column).await {
             Ok(()) => operations.succeed(&op_for_task),
             Err(e) => {
                 tracing::error!(

--- a/crates/firnflow-api/tests/api_namespace_info.rs
+++ b/crates/firnflow-api/tests/api_namespace_info.rs
@@ -99,7 +99,9 @@ async fn info_returns_namespace_metadata() {
     assert!(info["fragment_count"].as_u64().unwrap() >= 1);
     assert_eq!(info["has_vector_index"], json!(false));
     assert_eq!(info["has_fts_index"], json!(false));
-    assert_eq!(info["has_scalar_index"], json!(false));
+    // The first upsert auto-builds a BTree on `id`, so the scalar-index
+    // flag is set even before any explicit index build.
+    assert_eq!(info["has_scalar_index"], json!(true));
     assert!(
         info["table_version"].as_u64().unwrap() >= 1,
         "table version advances on commits"

--- a/crates/firnflow-api/tests/api_scalar_index.rs
+++ b/crates/firnflow-api/tests/api_scalar_index.rs
@@ -36,7 +36,7 @@ use serde_json::{json, Value};
 use tower::ServiceExt;
 
 mod common;
-use common::{test_state, unique_namespace};
+use common::{test_state, test_state_offline, unique_namespace};
 
 async fn build_app_with_metrics() -> (axum::Router, tempfile::TempDir, Arc<CoreMetrics>) {
     let (state, tmp) = test_state().await;
@@ -262,6 +262,63 @@ async fn scalar_index_build_returns_202_and_list_still_works() {
     //    same order — the index swap must not corrupt the read path.
     let after_rebuild = list_all_ids(&app, &ns_indexed, 5).await;
     assert_eq!(after_rebuild, expected);
+}
+
+/// The `column` parameter is validated synchronously, so an
+/// unsupported column returns `400` before any storage is touched —
+/// no MinIO required. Uses the offline state whose backend refuses
+/// connections, which the request never reaches.
+#[tokio::test]
+async fn scalar_index_rejects_unsupported_column() {
+    let (state, _tmp) = test_state_offline().await;
+    let app = router(state);
+    let ns = unique_namespace("scalar-col-bad");
+
+    let (status, _) = post_json(
+        app,
+        format!("/ns/{ns}/scalar-index"),
+        json!({ "column": "vector" }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an unsupported scalar-index column must be rejected with 400"
+    );
+}
+
+/// A supported column (`id`) and the no-body default both return
+/// `202` synchronously — the build itself runs in the background, so
+/// the immediate response does not depend on a reachable backend.
+#[tokio::test]
+async fn scalar_index_accepts_id_and_default_columns() {
+    let (state, _tmp) = test_state_offline().await;
+    let app = router(state);
+    let ns = unique_namespace("scalar-col-ok");
+
+    // Explicit `id` column (the merge-insert maintenance path).
+    let (status, body) = post_json(
+        app.clone(),
+        format!("/ns/{ns}/scalar-index"),
+        json!({ "column": "id" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "id column must be accepted");
+    assert!(
+        body["operation_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("op_")),
+        "202 should carry an operation id: {body}"
+    );
+
+    // No body: the column defaults to `_ingested_at`, preserving the
+    // original behaviour.
+    let (status, _) = post_empty(app, format!("/ns/{ns}/scalar-index")).await;
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "an empty body must default to _ingested_at and return 202"
+    );
 }
 
 #[tokio::test]

--- a/crates/firnflow-core/src/lib.rs
+++ b/crates/firnflow-core/src/lib.rs
@@ -20,8 +20,8 @@ pub mod vector;
 
 pub use error::FirnflowError;
 pub use manager::{
-    decode_list_cursor, encode_list_cursor, CompactResult, NamespaceManager, UpsertRow,
-    LIST_MAX_LIMIT,
+    decode_list_cursor, encode_list_cursor, validate_scalar_index_column, CompactResult,
+    NamespaceManager, UpsertRow, LIST_MAX_LIMIT,
 };
 pub use metrics::CoreMetrics;
 pub use namespace::NamespaceId;

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -77,12 +77,39 @@ const INGESTED_AT_COLUMN: &str = "_ingested_at";
 /// lacks scalar-index pushdown.
 pub const LIST_MAX_LIMIT: usize = 500;
 
-/// Columns the v1 `/scalar-index` endpoint will build a BTree on.
-/// Locked to `_ingested_at` to mirror the same constraint the
-/// `/list` endpoint puts on `order_by` — the BTree only earns its
-/// keep on columns the query path actually filters or orders by.
-/// Future user-column ordering work extends this slice.
-const SCALAR_INDEX_COLUMNS: &[&str] = &[INGESTED_AT_COLUMN];
+/// Columns the `/scalar-index` endpoint will build a BTree on.
+///
+/// - `id` accelerates merge-insert match-finding on the write path:
+///   without it, every `/upsert` batch scans each fragment to decide
+///   which incoming ids are updates and which are inserts, so write
+///   latency grows with table size. New namespaces get this index
+///   automatically on first write; the endpoint is the maintenance
+///   path for namespaces created before auto-indexing existed.
+/// - `_ingested_at` lets `/list` cursor pages do an index range scan
+///   instead of a full-fragment scan, mirroring the constraint the
+///   `/list` endpoint puts on `order_by`.
+///
+/// The BTree only earns its keep on columns the read or write path
+/// actually uses; future user-column ordering work extends this slice.
+const SCALAR_INDEX_COLUMNS: &[&str] = &["id", INGESTED_AT_COLUMN];
+
+/// Validate that `column` is one the scalar-index path will build a
+/// BTree on, returning [`FirnflowError::InvalidRequest`] otherwise.
+///
+/// Exposed so the API layer can reject an unsupported column with a
+/// synchronous `400` before it spawns the background build task —
+/// the same reasoning as [`crate::validate_ivf_pq_options`], which
+/// avoids a misleading `202` followed by a log-only failure.
+pub fn validate_scalar_index_column(column: &str) -> Result<(), FirnflowError> {
+    if SCALAR_INDEX_COLUMNS.contains(&column) {
+        Ok(())
+    } else {
+        Err(FirnflowError::InvalidRequest(format!(
+            "scalar index column {column:?} is not supported; \
+             valid columns: {SCALAR_INDEX_COLUMNS:?}"
+        )))
+    }
+}
 
 /// Per-namespace schema facts cached after the first table open.
 /// The resolved vector dimension, the kind of vector representation
@@ -535,9 +562,14 @@ impl NamespaceManager {
     /// inserted. Replaying the same request is therefore idempotent
     /// from the caller's point of view, and `_ingested_at` reflects
     /// the most recent write rather than the first insert. The merge
-    /// finds matches by scanning for `id`; there is no scalar index on
-    /// `id` yet, so writes to a large namespace pay a full-fragment
-    /// scan per batch (see issue #66 for the planned auto-built BTree).
+    /// finds matches on `id`; a BTree index on `id` lets that lookup
+    /// use the index instead of scanning every fragment, so on the
+    /// first write to a fresh namespace this builds that index once
+    /// (the table is still small). Namespaces created before this
+    /// behaviour existed can build it through `create_scalar_index`
+    /// with the `id` column. The build is best-effort: the write has
+    /// already committed by the time it runs, so a failure is logged
+    /// and the upsert still succeeds.
     ///
     /// Lance leaves merge behaviour undefined when several source rows
     /// match the same target row, so duplicate ids within a single
@@ -569,16 +601,22 @@ impl NamespaceManager {
         // Determine schema facts: cached → live schema → infer for
         // a fresh namespace. Fresh namespaces always get the current
         // schema (with `_ingested_at`); pre-upgrade tables keep their
-        // legacy shape so writes continue to match.
-        let info = match self.resolve_schema_info(ns).await? {
-            Some(info) => info,
+        // legacy shape so writes continue to match. A `None` here
+        // means the table does not exist yet, so this call creates it
+        // — the one moment we build the `id` index, while it is empty
+        // or near-empty.
+        let (info, is_fresh) = match self.resolve_schema_info(ns).await? {
+            Some(info) => (info, false),
             None => {
                 let (kind, dim) = inspect_row_payload(&rows[0])?;
-                NamespaceSchemaInfo {
-                    dim,
-                    kind,
-                    has_ingested_at: true,
-                }
+                (
+                    NamespaceSchemaInfo {
+                        dim,
+                        kind,
+                        has_ingested_at: true,
+                    },
+                    true,
+                )
             }
         };
 
@@ -609,6 +647,43 @@ impl NamespaceManager {
             .map_err(|e| FirnflowError::Backend(format!("table.merge_insert: {e}")))?;
 
         self.schema_info.insert(ns.clone(), info);
+
+        // On the namespace's first write, build a BTree on `id` so
+        // every subsequent merge-insert finds its matches through the
+        // index rather than scanning each fragment — the write-path
+        // cost that otherwise grows with table size. Best-effort: the
+        // rows above are already durable, so an index-build failure is
+        // logged and the upsert still returns success (the index can
+        // be rebuilt later through `create_scalar_index`).
+        if is_fresh {
+            if let Err(e) = self.build_id_index(&tbl).await {
+                tracing::warn!(
+                    namespace = %ns,
+                    error = %e,
+                    "auto-build of id index failed on first write; \
+                     rebuild it with POST /ns/{ns}/scalar-index column=id"
+                );
+            } else {
+                // The index build is a Lance commit that advances the
+                // manifest, so drop the pooled handle — the next
+                // operation re-opens at the new version. Matches the
+                // eviction the explicit index builders do.
+                self.evict_handle(ns);
+            }
+        }
+        Ok(())
+    }
+
+    /// Build a BTree scalar index on the `id` column of an already
+    /// open table. Used by [`upsert`](Self::upsert) on a namespace's
+    /// first write and by [`create_scalar_index`](Self::create_scalar_index)
+    /// for the `id` maintenance path. Idempotent: `lancedb`'s
+    /// `IndexBuilder` defaults to `replace=true`.
+    async fn build_id_index(&self, tbl: &lancedb::Table) -> Result<(), FirnflowError> {
+        tbl.create_index(&["id"], Index::BTree(BTreeIndexBuilder::default()))
+            .execute()
+            .await
+            .map_err(|e| FirnflowError::Backend(format!("build id index: {e}")))?;
         Ok(())
     }
 
@@ -1055,18 +1130,23 @@ impl NamespaceManager {
 
     /// Build a BTree scalar index on a namespace column.
     ///
-    /// v1 only accepts `_ingested_at` (see [`SCALAR_INDEX_COLUMNS`]).
-    /// The index lets `/list` cursor pages do an index range scan
-    /// instead of a full-fragment scan and lets the leading
+    /// Accepts the columns in [`SCALAR_INDEX_COLUMNS`]: `id` to speed
+    /// up merge-insert match-finding on the write path, and
+    /// `_ingested_at` to let `/list` cursor pages do an index range
+    /// scan instead of a full-fragment scan and let the leading
     /// `ORDER BY _ingested_at` short-circuit the in-memory sort.
+    ///
+    /// New namespaces get the `id` index automatically on first
+    /// write; this endpoint is the maintenance path for building it
+    /// on namespaces created before auto-indexing existed.
     ///
     /// Idempotent: `lancedb`'s `IndexBuilder` defaults to
     /// `replace=true`, so a repeat call rebuilds the index in place
     /// rather than failing.
     ///
     /// Returns [`FirnflowError::Unsupported`] for namespaces whose
-    /// tables pre-date the `_ingested_at` column — same gate the
-    /// `/list` endpoint applies.
+    /// tables pre-date the `_ingested_at` column when that column is
+    /// requested — same gate the `/list` endpoint applies.
     ///
     /// Like the other index builders, this is potentially expensive
     /// on large tables; the API handler runs it in a background task.
@@ -1075,12 +1155,7 @@ impl NamespaceManager {
         ns: &NamespaceId,
         column: &str,
     ) -> Result<(), FirnflowError> {
-        if !SCALAR_INDEX_COLUMNS.contains(&column) {
-            return Err(FirnflowError::InvalidRequest(format!(
-                "scalar index column {column:?} is not supported in v1; \
-                 valid columns: {SCALAR_INDEX_COLUMNS:?}"
-            )));
-        }
+        validate_scalar_index_column(column)?;
 
         let info = self.resolve_schema_info(ns).await?.ok_or_else(|| {
             FirnflowError::InvalidRequest(format!(
@@ -1818,6 +1893,22 @@ mod tests {
     #[test]
     fn cursor_rejects_non_hex() {
         assert!(decode_list_cursor(&"z".repeat(32)).is_err());
+    }
+
+    #[test]
+    fn scalar_index_column_validation() {
+        // Both supported columns pass.
+        assert!(validate_scalar_index_column("id").is_ok());
+        assert!(validate_scalar_index_column(INGESTED_AT_COLUMN).is_ok());
+        // Anything else is a 400-mapped InvalidRequest.
+        assert!(matches!(
+            validate_scalar_index_column("vector"),
+            Err(FirnflowError::InvalidRequest(_))
+        ));
+        assert!(matches!(
+            validate_scalar_index_column("text"),
+            Err(FirnflowError::InvalidRequest(_))
+        ));
     }
 
     #[test]

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -656,19 +656,34 @@ impl NamespaceManager {
         // logged and the upsert still returns success (the index can
         // be rebuilt later through `create_scalar_index`).
         if is_fresh {
-            if let Err(e) = self.build_id_index(&tbl).await {
-                tracing::warn!(
-                    namespace = %ns,
-                    error = %e,
-                    "auto-build of id index failed on first write; \
-                     rebuild it with POST /ns/{ns}/scalar-index column=id"
-                );
-            } else {
-                // The index build is a Lance commit that advances the
-                // manifest, so drop the pooled handle — the next
-                // operation re-opens at the new version. Matches the
-                // eviction the explicit index builders do.
-                self.evict_handle(ns);
+            match self.build_id_index(&tbl).await {
+                Ok(()) => {
+                    // The index build is a Lance commit, so the handle
+                    // pooled while creating the table now references the
+                    // pre-index view. Drop it and open a fresh one in its
+                    // place: later merge-insert batches then see and use
+                    // the index, and the pool stays warm — an upsert must
+                    // not leave it cold (the explicit index builders evict
+                    // and let the next call re-open lazily; here the next
+                    // call is the warm upsert, so re-pool eagerly).
+                    self.evict_handle(ns);
+                    if let Err(e) = self.get_or_open_table(ns, info.kind, info.dim).await {
+                        tracing::warn!(
+                            namespace = %ns,
+                            error = %e,
+                            "could not re-pool handle after id index build; \
+                             it will reopen on the next operation"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        namespace = %ns,
+                        error = %e,
+                        "auto-build of id index failed on first write; \
+                         rebuild it with POST /ns/{ns}/scalar-index column=id"
+                    );
+                }
             }
         }
         Ok(())

--- a/crates/firnflow-core/tests/manager_connection_pool.rs
+++ b/crates/firnflow-core/tests/manager_connection_pool.rs
@@ -295,8 +295,10 @@ async fn handle_evicted_after_scalar_index_build() {
 
     // Reject unsupported columns — the validation lives in
     // `NamespaceManager::create_scalar_index`, not the API layer.
+    // (`id` and `_ingested_at` are the supported columns; `vector` is
+    // not.)
     let err = manager
-        .create_scalar_index(&ns, "id")
+        .create_scalar_index(&ns, "vector")
         .await
         .expect_err("must reject non-whitelisted column");
     let msg = err.to_string();

--- a/crates/firnflow-core/tests/manager_idempotent_upsert.rs
+++ b/crates/firnflow-core/tests/manager_idempotent_upsert.rs
@@ -343,3 +343,50 @@ async fn concurrent_merge_insert_same_id_keeps_single_row() {
          untouched id=2 row remain (no duplicates, no lost neighbour)"
     );
 }
+
+/// A namespace's first write auto-builds a BTree on `id` so later
+/// merge-insert batches find their matches through the index instead
+/// of scanning every fragment (issue #77). The maintenance path —
+/// building the same index explicitly through `create_scalar_index`
+/// — must also succeed and be idempotent for namespaces created
+/// before auto-indexing existed.
+#[tokio::test]
+#[ignore]
+async fn first_upsert_auto_builds_id_index() {
+    let manager = manager();
+    let ns = NamespaceId::new(unique_namespace("idem-idindex")).unwrap();
+
+    manager
+        .upsert(&ns, vec![row(1, unit_vector(0), "v1")])
+        .await
+        .expect("first upsert");
+
+    let info = manager.info(&ns).await.expect("info").expect("namespace");
+    assert!(
+        info.has_scalar_index,
+        "the first write must auto-build a scalar (BTree) index on id"
+    );
+    assert_eq!(info.row_count, 1, "the auto-index must not drop the row");
+
+    // A second write into the now-indexed namespace still merges
+    // correctly (the index is on the write-path lookup, not a barrier).
+    manager
+        .upsert(&ns, vec![row(2, unit_vector(1), "v2")])
+        .await
+        .expect("second upsert");
+    let info = manager.info(&ns).await.expect("info").expect("namespace");
+    assert_eq!(info.row_count, 2, "second distinct id appends a row");
+
+    // Maintenance path: building the id index explicitly is idempotent
+    // (lancedb's IndexBuilder defaults to replace=true), so an operator
+    // can run it on a pre-existing namespace without it failing.
+    manager
+        .create_scalar_index(&ns, "id")
+        .await
+        .expect("explicit id index rebuild");
+    let info = manager.info(&ns).await.expect("info").expect("namespace");
+    assert!(
+        info.has_scalar_index,
+        "id index still present after rebuild"
+    );
+}

--- a/crates/firnflow-core/tests/manager_namespace_info.rs
+++ b/crates/firnflow-core/tests/manager_namespace_info.rs
@@ -99,7 +99,12 @@ async fn info_reports_namespace_state_and_index_flags() {
     assert!(info.fragment_count >= 1, "at least one data fragment");
     assert!(!info.has_vector_index);
     assert!(!info.has_fts_index);
-    assert!(!info.has_scalar_index);
+    // The first upsert auto-builds a BTree on `id`, so the scalar-index
+    // flag is set even before any explicit index build.
+    assert!(
+        info.has_scalar_index,
+        "first upsert auto-builds the id index"
+    );
     assert!(info.table_version >= 1, "version advances on commits");
 
     // Both builds are synchronous at the manager layer.

--- a/docs/api.html
+++ b/docs/api.html
@@ -113,6 +113,7 @@
       <div class="endpoint-body">
         <p>Inserts or updates rows in the namespace's Lance table, keyed by <code>id</code>. The vector dimension and the vector kind (single-vector or multivector) are inferred from the first upsert and enforced on subsequent calls. After a successful write, all cached query results for this namespace are invalidated.</p>
         <p>Upsert is latest-write-wins: re-sending a row whose <code>id</code> already exists replaces the stored row in full (vector, text, and the <code>_ingested_at</code> timestamp), so replaying a request and updating a document are both safe. A row with a new <code>id</code> is inserted. Because <code>_ingested_at</code> is rewritten on update, it reflects the most recent write to a row rather than its first insert. Duplicate ids within a single request are rejected with <code>400</code>.</p>
+        <p>The first write to a namespace builds a BTree index on <code>id</code> automatically, so the per-batch merge that matches incoming ids against stored rows uses the index instead of scanning every data file. For a large first load, see the recommended load/compact/index recipe in the README; for namespaces created before this behaviour existed, build the index once via <code>POST /ns/{namespace}/scalar-index</code> with <code>{"column": "id"}</code>.</p>
         <div class="callout callout-warning">
           <div class="callout-title">Upgrade note</div>
           Idempotent upsert does not retroactively de-duplicate older data. A namespace that accumulated duplicate ids under earlier (append-only) versions keeps those rows, and merging into a target that already holds duplicate ids is undefined, so <code>/query</code> and <code>/list</code> can still surface them until those ids are cleared (delete and re-ingest, or wait on the dedupe pass tracked in issue #68). Namespaces written only by this release forward are unaffected.
@@ -539,13 +540,13 @@
       <div class="endpoint-header" aria-expanded="true">
         <span class="method method-post">POST</span>
         <span class="endpoint-path">/ns/{namespace}/scalar-index</span>
-        <span class="endpoint-desc">Build BTree index on <code>_ingested_at</code> to accelerate <code>/list</code> (async)</span>
+        <span class="endpoint-desc">Build a BTree index on a column (async)</span>
       </div>
       <div class="endpoint-body">
-        <p>Builds a BTree scalar index on the reserved <code>_ingested_at</code> column. With the index in place, <code>/list</code> cursor pages do an index range scan instead of a full-fragment scan, and the leading <code>ORDER BY _ingested_at</code> short-circuits the in-memory sort step. Returns <code>202 Accepted</code>.</p>
+        <p>Builds a BTree scalar index on a namespace column. On <code>_ingested_at</code> (the default) the index lets <code>/list</code> cursor pages do an index range scan instead of a full-fragment scan, and the leading <code>ORDER BY _ingested_at</code> short-circuits the in-memory sort step. On <code>id</code> it speeds up the per-batch merge-insert lookup the write path runs (see <code>/upsert</code>). Returns <code>202 Accepted</code>.</p>
 
         <h4>Request body</h4>
-        <p>No request body required. v1 hardcodes the column to <code>_ingested_at</code> — the same constraint <code>/list</code> puts on <code>order_by</code>.</p>
+        <p>Optional. <code>{"column": "id"}</code> indexes the row id; an empty body defaults to <code>_ingested_at</code>. Valid columns are <code>id</code> and <code>_ingested_at</code>; any other value returns <code>400</code> before the background build starts. A namespace's first write already builds the <code>id</code> index automatically, so this is the maintenance path for namespaces created before that behaviour existed.</p>
 
         <h4>Response (202)</h4>
         <pre><code>{
@@ -556,7 +557,12 @@
 }</code></pre>
 
         <h4>Example</h4>
-        <pre><code>curl -X POST http://localhost:3000/ns/demo/scalar-index</code></pre>
+        <pre><code>curl -X POST http://localhost:3000/ns/demo/scalar-index
+
+# index the row id (write-path maintenance path)
+curl -X POST http://localhost:3000/ns/demo/scalar-index \
+     -H 'Content-Type: application/json' \
+     -d '{"column": "id"}'</code></pre>
 
         <div class="callout callout-info">
           <div class="callout-title">Idempotent and self-maintaining</div>


### PR DESCRIPTION
## Summary

- Auto-build a BTree scalar index on `id` on a namespace's first write so later `merge_insert(&["id"])` calls can use the index.
- Allow `/scalar-index` to rebuild either `_ingested_at` or `id`, defaulting to `_ingested_at` for existing callers.
- Document the large-ingest recipe: load, compact, index, then query.

Closes #66.
Refs #77.

## Behavior notes

- First-write `id` indexing is best-effort: the upsert commits first, and index build failures are logged without failing the write.
- `/scalar-index` now accepts an optional body like `{"column":"id"}`.
- Invalid scalar-index columns return `400`, validated synchronously before any background work starts.
- This does not fully solve #77. Bulk import, write-path instrumentation, and high-frequency ingest cleanup behavior remain follow-up work. The auto-index alone does not flatten throughput on a long append-heavy load, since rows written after the build land in unindexed fragments until a compaction folds them in.

## Tests

~~~text
./scripts/cargo fmt --all -- --check
./scripts/cargo clippy -p firnflow-core -p firnflow-api --all-targets -j 1 -- -D warnings
./scripts/cargo test -p firnflow-core --lib scalar_index_column_validation -j 1
./scripts/cargo test -p firnflow-api --test api_scalar_index -j 1 -- \
    scalar_index_rejects_unsupported_column scalar_index_accepts_id_and_default_columns

# MinIO up (docker compose up -d minio minio-init):
./scripts/cargo test -p firnflow-core --test manager_idempotent_upsert -j 1 -- --ignored
./scripts/cargo test -p firnflow-api --test api_scalar_index -j 1 -- --ignored

cargo test --workspace was deliberately skipped on this host (16 GB RAM,
disk-tight target/) to avoid the parallel link of every workspace + test
binary against Lance. The MinIO-gated suites above were run against the
local docker-compose stack; the BEIR-scale S3 ingest that #77's "done when"
calls for was not run here.
~~~
