### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-06-19
+
 ### Added
 - `POST /ns/{namespace}/scalar-index` takes an optional JSON body to choose which column to index. `{"column": "id"}` builds a BTree on the row id, and a request with no body keeps the previous default of `_ingested_at`. The `id` index is the maintenance path for namespaces created before auto-indexing existed (see Changed), so an operator can add it to an existing namespace without recreating it. An unsupported column is rejected with `400` before any background work starts. Closes #66.
 
@@ -214,7 +216,8 @@ development through phases 1 through 8 before being made public;
   benchmark at dim=1536, 100k rows available at
   `bench/results/cold_vs_warm_aws.md`.
 
-[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/gordonmurray/firnflow/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/gordonmurray/firnflow/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/gordonmurray/firnflow/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/gordonmurray/firnflow/compare/v0.7.1...v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firnflow-api"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-bench"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cut v0.9.1. Bumps the workspace version to 0.9.1 and finalizes the CHANGELOG for the release.

This release bundles two backward-compatible changes that landed on main since v0.9.0:

- **Large-ingest write throughput (#66, #78).** The first write to a namespace auto-builds a BTree on `id`, so the per-batch merge-insert finds its matches through the index instead of scanning every data file. `/scalar-index` now also takes an optional `{"column": "id"}` body as the maintenance path for namespaces created before auto-indexing.
- **S3 region resolution (#76).** Region now honours `AWS_REGION` and `AWS_DEFAULT_REGION`, not just `FIRNFLOW_S3_REGION`, so a deployment that sets the region the conventional way no longer silently talks to `us-east-1`.

## Behavior notes

- Existing callers are unaffected: a no-body `/scalar-index` still defaults to `_ingested_at`, and `/upsert` semantics are unchanged apart from the one-time index build on a namespace's first write.
- This is a patch release: both items are refinements rather than a new headline feature, matching the 0.7.1 / 0.8.1 precedent.
- Pushing the `v0.9.1` tag triggers `docker-publish.yml`, which publishes `ghcr.io/gordonmurray/firnflow:0.9.1` and moves the `latest` tag. Tag after this merges.

## Tests

~~~text
./scripts/cargo check -p firnflow-core -p firnflow-api -j 1
~~~

No source changes in this PR beyond the version bump and CHANGELOG; the code shipped here was tested under #76 and #78 (the latter verified against the MinIO-backed integration suites). CI runs the full check on the release branch.

Refs #66, #76, #77.
