### PR TITLE
Add a binary Arrow /import bulk-ingest endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `POST /ns/{namespace}/import` bulk-ingests an Arrow IPC stream. It is the binary, columnar path for large first loads: the body is an Arrow IPC stream rather than JSON, so embeddings avoid JSON's ~3x decimal-text inflation, the route is not bound by `FIRNFLOW_MAX_BODY_BYTES` (a whole corpus can stream in one request), and the entire stream is appended in a single Lance commit. That last part is the point: on a large load, the per-batch commit and small-fragment bookkeeping of many small `/upsert` calls is what makes throughput decay as a namespace grows, and a single streamed commit removes it. The stream carries `id` (`UInt64`) plus exactly one of `vector` (`FixedSizeList<Float32, dim>`) or `vectors` (`List<FixedSizeList<Float32, dim>>`) and an optional `text` (`Utf8`); `_ingested_at` is server-set. It is **insert-only** (a repeated `id` makes a second row), so it is for first-loads or known-new ids, not idempotent updates — use `/upsert` for those. The handler validates the schema synchronously (`400`/`413`/`415`) then returns `202` with an `operation_id` and runs the append in the background; poll `GET /operations/{operation_id}`. Recommended large-ingest path: import, then compact, then build indexes, then query (documented in the README). Part of the large-ingest work in #77.
+- Two env vars tune `/import`: `FIRNFLOW_IMPORT_MAX_BYTES` caps a single import body spooled to disk (default 8 GiB; `0` disables the cap, exceeding it returns `413`), and `FIRNFLOW_IMPORT_TMP_DIR` sets the spool directory (default the system temp dir).
+
 ## [0.9.1] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,9 +2547,13 @@ name = "firnflow-api"
 version = "0.9.1"
 dependencies = [
  "anyhow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "axum",
  "dashmap",
  "firnflow-core",
+ "futures",
  "governor",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ lance = "=6.0.0"
 # the minor keeps the dependency graph on what upstream tested.
 arrow-array = "58"
 arrow-schema = "58"
+# Arrow IPC stream reader for the binary `/import` bulk-ingest path;
+# pinned to the same arrow-rs minor as the rest of the stack.
+arrow-ipc = "58"
 
 # `object_store` — lance-io 6.0.0 still takes `^0.12.0`. Used by the
 # DELETE path in `NamespaceManager` to list and delete the namespace

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ If `FIRNFLOW_ADMIN_API_KEY` is unset, the read/write key authorises admin routes
 | `/ns/{ns}` | `GET` | read/write | Namespace metadata (row count, fragment count, indexes, table version); 404 if it has no data yet |
 | `/ns/{ns}` | `DELETE` | admin | Removes all data (object storage + cache) for a namespace |
 | `/ns/{ns}/upsert` | `POST` | read/write | Insert or update vectors and data (latest-write-wins by `id`) |
+| `/ns/{ns}/import` | `POST` | read/write | Bulk-ingest an Arrow IPC stream (binary, insert-only, async 202). For large first loads; bypasses the JSON body limit |
 | `/ns/{ns}/query` | `POST` | read/write | Vector, FTS, or hybrid search |
 | `/ns/{ns}/list` | `GET` | read/write | Cursor-paginated list ordered by `_ingested_at` |
 | `/ns/{ns}/warmup` | `POST` | read/write | Non-blocking cache pre-warm hint |
@@ -258,7 +259,7 @@ If `FIRNFLOW_ADMIN_API_KEY` is unset, the read/write key authorises admin routes
 | `/ns/{ns}/compact` | `POST` | admin | Compact and prune data files (async, returns 202) |
 | `/operations/{id}` | `GET` | read/write | Status of a background operation by the `operation_id` from its 202; 404 if unknown or evicted |
 
-The async endpoints (`warmup`, `index`, `fts-index`, `scalar-index`, `compact`) return an opaque `operation_id` in their `202`; poll `GET /operations/{id}` to see whether the work is `running`, `succeeded`, or `failed` instead of inferring it from metrics.
+The async endpoints (`import`, `warmup`, `index`, `fts-index`, `scalar-index`, `compact`) return an opaque `operation_id` in their `202`; poll `GET /operations/{id}` to see whether the work is `running`, `succeeded`, or `failed` instead of inferring it from metrics.
 
 Auth column: `open` = no header required; `read/write` = `FIRNFLOW_API_KEY` (or `FIRNFLOW_ADMIN_API_KEY`); `admin` = `FIRNFLOW_ADMIN_API_KEY` if configured, otherwise `FIRNFLOW_API_KEY` via the single-key fallback. `/metrics` is `metrics` when `FIRNFLOW_METRICS_TOKEN` is set, otherwise `open`.
 
@@ -268,19 +269,18 @@ Two ingest shapes have different cost profiles, and it helps to treat them diffe
 
 **Idempotent updates** (retries, re-ingesting changed documents) are what `/upsert` is built for. It is keyed by `id` and latest-write-wins, so re-sending a row is safe. The first write to a namespace builds a BTree on `id`, which is what the per-batch merge-insert uses to find existing rows instead of scanning every data file.
 
-**A large first load** (millions of rows into a fresh namespace over S3) needs a bit more care. Every `/upsert` is a separate commit, so a long run of small batches produces many small data files, and the per-commit and per-file bookkeeping adds up. Two things keep throughput steady:
+**A large first load** (millions of rows into a fresh namespace over S3) should use `POST /ns/{ns}/import`. The `/upsert` JSON path has two costs at this scale: every call is a separate Lance commit, so a long run of small batches piles up commit and small-fragment bookkeeping, and JSON encodes each `f32` as decimal text (~3x the bytes of the 4-byte binary form), which also runs into the `FIRNFLOW_MAX_BODY_BYTES` limit. `/import` avoids both: the body is an [Arrow IPC stream](https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format) (binary, columnar, no float inflation), the route is not bound by the body limit (so a whole corpus can stream in one request), and the entire stream is appended in a single commit.
 
-- **Use larger batches.** Fewer, bigger commits beat many tiny ones. The body limit is `FIRNFLOW_MAX_BODY_BYTES` (default 16 MB), so size batches up toward that rather than sending rows a handful at a time.
-- **Build indexes after the bulk load, not during it.** Index builds are most efficient over settled data.
+It is insert-only: a repeated `id` makes a second row, so `/import` is for first-loads or known-new ids, not idempotent updates (use `/upsert` for those). The request streams its body to disk and returns `202` with an `operation_id` once validated; poll `GET /operations/{id}` for completion. The byte cap is `FIRNFLOW_IMPORT_MAX_BYTES` (default 8 GiB; `0` disables it) and the spool directory is `FIRNFLOW_IMPORT_TMP_DIR` (default the system temp dir).
 
 A recommended recipe for a first load:
 
-1. **Load** the data in large `/upsert` batches.
-2. **Compact** once the load is done: `POST /ns/{ns}/compact`. This merges the many small data files into fewer large ones and folds freshly written rows into the existing `id` index.
-3. **Build the query indexes**: `POST /ns/{ns}/index` (vector), `POST /ns/{ns}/fts-index` (full-text), and `POST /ns/{ns}/scalar-index` with `{"column": "_ingested_at"}` if you page with `/list`. These are async; poll `GET /operations/{id}`.
+1. **Load** the data with `POST /ns/{ns}/import` (one Arrow IPC stream, or a few large ones).
+2. **Compact** once the load is done: `POST /ns/{ns}/compact`. This merges data files into fewer large ones.
+3. **Build the query indexes**: `POST /ns/{ns}/index` (vector), `POST /ns/{ns}/fts-index` (full-text), `POST /ns/{ns}/scalar-index` with `{"column": "id"}` if you will then do idempotent `/upsert` updates, and `{"column": "_ingested_at"}` if you page with `/list`. These are async; poll `GET /operations/{id}`.
 4. **Query.**
 
-For a namespace created before auto-indexing existed, build the `id` index once with `POST /ns/{ns}/scalar-index -d '{"column": "id"}'` to get the same write-path benefit.
+If you stay on the JSON `/upsert` path (smaller loads, or idempotent updates), size batches up toward `FIRNFLOW_MAX_BODY_BYTES` rather than sending rows a handful at a time, and build indexes after the load rather than during it.
 
 ## Multivector namespaces
 

--- a/crates/firnflow-api/Cargo.toml
+++ b/crates/firnflow-api/Cargo.toml
@@ -27,6 +27,11 @@ governor.workspace = true
 subtle.workspace = true
 dashmap.workspace = true
 uuid.workspace = true
+arrow-array.workspace = true
+arrow-schema.workspace = true
+arrow-ipc.workspace = true
+futures.workspace = true
+tempfile = "3"
 firnflow-core = { path = "../firnflow-core" }
 
 [dev-dependencies]

--- a/crates/firnflow-api/src/config.rs
+++ b/crates/firnflow-api/src/config.rs
@@ -71,6 +71,16 @@ pub struct AppConfig {
     /// stream straight through uncached, bounding the RAM one miss can use.
     /// `FIRNFLOW_OBJECT_CACHE_MAX_ENTRY_BYTES` (default 256 MiB).
     pub object_cache_max_entry_bytes: u64,
+    /// Cap on a single `/import` Arrow body, spooled to disk. The
+    /// endpoint streams its body past the `DefaultBodyLimit`, so this is
+    /// the replacement guard against filling the spool disk; exceeding it
+    /// returns `413`. `FIRNFLOW_IMPORT_MAX_BYTES` (default 8 GiB; `0` ⇒
+    /// unlimited).
+    pub import_max_bytes: u64,
+    /// Directory the `/import` handler spools the request body to before
+    /// reading it as an Arrow stream. `FIRNFLOW_IMPORT_TMP_DIR` (default
+    /// the system temp dir).
+    pub import_tmp_dir: PathBuf,
 }
 
 /// True when the given storage-options key holds credential-bearing
@@ -166,6 +176,15 @@ impl AppConfig {
                 .parse()
                 .context("FIRNFLOW_OBJECT_CACHE_MAX_ENTRY_BYTES")?;
 
+        // Default 8 GiB; `0` disables the cap.
+        let import_max_bytes: u64 = env_or("FIRNFLOW_IMPORT_MAX_BYTES", "8589934592")
+            .parse()
+            .context("FIRNFLOW_IMPORT_MAX_BYTES")?;
+        let import_tmp_dir = match std::env::var("FIRNFLOW_IMPORT_TMP_DIR") {
+            Ok(dir) => PathBuf::from(dir),
+            Err(_) => std::env::temp_dir(),
+        };
+
         let storage_options = build_storage_options_for(storage_root.scheme());
 
         let api_key = optional_secret("FIRNFLOW_API_KEY");
@@ -200,6 +219,8 @@ impl AppConfig {
             object_cache_dir,
             object_cache_bytes,
             object_cache_max_entry_bytes,
+            import_max_bytes,
+            import_tmp_dir,
         })
     }
 }
@@ -495,6 +516,8 @@ mod tests {
             object_cache_dir: std::env::temp_dir(),
             object_cache_bytes: 0,
             object_cache_max_entry_bytes: 0,
+            import_max_bytes: 0,
+            import_tmp_dir: std::env::temp_dir(),
         };
 
         let dbg = format!("{:?}", cfg);
@@ -557,6 +580,8 @@ mod tests {
             object_cache_dir: std::env::temp_dir(),
             object_cache_bytes: 0,
             object_cache_max_entry_bytes: 0,
+            import_max_bytes: 0,
+            import_tmp_dir: std::env::temp_dir(),
         };
 
         let dbg = format!("{:?}", cfg);

--- a/crates/firnflow-api/src/handlers.rs
+++ b/crates/firnflow-api/src/handlers.rs
@@ -2,6 +2,7 @@
 //!
 //! * `GET    /health`
 //! * `POST   /ns/{namespace}/upsert`
+//! * `POST   /ns/{namespace}/import`
 //! * `POST   /ns/{namespace}/query`
 //! * `GET    /ns/{namespace}/list`
 //! * `GET    /ns/{namespace}`
@@ -14,18 +15,23 @@
 //! * `GET    /operations/{operation_id}`
 //! * `GET    /metrics`
 
+use std::io::{BufReader, Write};
 use std::sync::Arc;
 
+use arrow_array::RecordBatchReader;
+use arrow_ipc::reader::StreamReader;
+use axum::body::Body;
 use axum::extract::{Path, Query, State};
 use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
 use firnflow_core::{
-    decode_list_cursor, FirnflowError, IndexRequest, ListOrder, ListPage, NamespaceId,
-    NamespaceInfo, QueryRequest, UpsertRow as CoreUpsertRow, LIST_MAX_LIMIT,
+    decode_list_cursor, validate_arrow_import_schema, FirnflowError, IndexRequest, ListOrder,
+    ListPage, NamespaceId, NamespaceInfo, QueryRequest, UpsertRow as CoreUpsertRow, LIST_MAX_LIMIT,
 };
 
 use crate::error::ApiError;
@@ -34,6 +40,10 @@ use crate::state::AppState;
 
 const CACHE_SOURCE_REQUEST_HEADER: &str = "x-firn-debug-cache-source";
 const CACHE_SOURCE_RESPONSE_HEADER: &str = "x-firn-cache-source";
+
+/// Canonical `Content-Type` for an Arrow IPC stream body on `/import`.
+/// `application/octet-stream` is also accepted as a binary fallback.
+const ARROW_STREAM_CONTENT_TYPE: &str = "application/vnd.apache.arrow.stream";
 
 /// Body of a successful delete response.
 #[derive(Debug, Serialize)]
@@ -452,6 +462,139 @@ pub async fn create_scalar_index(
             status: OperationStatus::Running,
         }),
     ))
+}
+
+/// JSON error response with an explicit status, matching the
+/// `{ "error": ... }` body shape the rest of the API uses. Used by
+/// [`import`] for the statuses `ApiError` does not model (415, 413).
+fn status_error(status: StatusCode, msg: impl Into<String>) -> Response {
+    (status, Json(serde_json::json!({ "error": msg.into() }))).into_response()
+}
+
+/// Bulk-ingest rows from an Arrow IPC stream (`POST /ns/{ns}/import`).
+///
+/// The binary, columnar bulk-load path: the body is an Arrow IPC stream
+/// (`Content-Type: application/vnd.apache.arrow.stream`), not JSON, so
+/// it avoids JSON's ~3x float inflation and is not bound by
+/// `FIRNFLOW_MAX_BODY_BYTES` (this route disables that limit). The whole
+/// stream is appended in a single Lance commit, insert-only — see
+/// [`firnflow_core::NamespaceManager::import_arrow`] for the schema
+/// contract and semantics; it is **not** idempotent (use `/upsert` for
+/// that). Build indexes after the load (the large-ingest recipe).
+///
+/// Flow: validate `Content-Type` (415 otherwise) → spool the body to a
+/// temp file, enforcing `FIRNFLOW_IMPORT_MAX_BYTES` (413 if exceeded) →
+/// validate the Arrow schema (400 if malformed/wrong) → start an
+/// operation, run the import in the background, return `202` with an
+/// `operation_id`. Poll `GET /operations/{operation_id}`; stream-time
+/// failures (bad rows, truncated stream, storage errors) surface as a
+/// failed operation.
+pub async fn import(
+    State(state): State<AppState>,
+    Path(namespace): Path<String>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<Response, ApiError> {
+    let ns = NamespaceId::new(namespace)?;
+
+    // Binary transport only. Accept the canonical Arrow stream type or
+    // a generic octet-stream; reject anything else (e.g. JSON).
+    let content_type = headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.split(';').next().unwrap_or("").trim().to_string())
+        .unwrap_or_default();
+    if content_type != ARROW_STREAM_CONTENT_TYPE && content_type != "application/octet-stream" {
+        return Ok(status_error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            format!("import requires Content-Type: {ARROW_STREAM_CONTENT_TYPE}"),
+        ));
+    }
+
+    // Spool the body to disk so the Lance write/commit can run in the
+    // background after a fast 202, and so memory stays bounded. The
+    // route bypasses the global body limit, so the import-specific byte
+    // cap is the guard against filling the spool disk.
+    let mut tmp = tempfile::Builder::new()
+        .prefix("firnflow-import-")
+        .tempfile_in(&state.import_tmp_dir)
+        .map_err(|e| FirnflowError::Backend(format!("import: create temp file: {e}")))?;
+    let cap = state.import_max_bytes;
+    let mut written: u64 = 0;
+    let mut stream = body.into_data_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .map_err(|e| FirnflowError::InvalidRequest(format!("import: body read error: {e}")))?;
+        written += chunk.len() as u64;
+        if cap != 0 && written > cap {
+            return Ok(status_error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!("import body exceeds FIRNFLOW_IMPORT_MAX_BYTES ({cap} bytes)"),
+            ));
+        }
+        tmp.write_all(&chunk)
+            .map_err(|e| FirnflowError::Backend(format!("import: spool write: {e}")))?;
+    }
+    tmp.flush()
+        .map_err(|e| FirnflowError::Backend(format!("import: spool flush: {e}")))?;
+
+    // Validate the Arrow schema up front so a bad request is a 400
+    // before any background work starts (the schema is the first IPC
+    // message, so this is cheap).
+    let schema = {
+        let file = tmp
+            .reopen()
+            .map_err(|e| FirnflowError::Backend(format!("import: reopen temp: {e}")))?;
+        let reader = StreamReader::try_new(BufReader::new(file), None).map_err(|e| {
+            FirnflowError::InvalidRequest(format!("import: not a valid Arrow IPC stream: {e}"))
+        })?;
+        reader.schema()
+    };
+    validate_arrow_import_schema(&schema).map_err(ApiError::Core)?;
+
+    let operation_id = state
+        .operations
+        .start(OperationKind::Import, ns.to_string());
+    let service = Arc::clone(&state.service);
+    let operations = Arc::clone(&state.operations);
+    let ns_owned = ns.clone();
+    let op_for_task = operation_id.clone();
+    tokio::spawn(async move {
+        // `tmp` is moved in so the spooled file outlives the response and
+        // is removed when the task ends.
+        let reader = match tmp.reopen() {
+            Ok(file) => match StreamReader::try_new(BufReader::new(file), None) {
+                Ok(r) => r,
+                Err(e) => {
+                    operations.fail(&op_for_task, format!("import: Arrow stream: {e}"));
+                    return;
+                }
+            },
+            Err(e) => {
+                operations.fail(&op_for_task, format!("import: reopen temp: {e}"));
+                return;
+            }
+        };
+        let reader: Box<dyn RecordBatchReader + Send> = Box::new(reader);
+        match service.import(&ns_owned, reader).await {
+            Ok(_imported) => operations.succeed(&op_for_task),
+            Err(e) => {
+                tracing::error!(namespace = %ns_owned, error = %e, "import failed");
+                operations.fail(&op_for_task, operation_error_message(&e));
+            }
+        }
+    });
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(OperationAccepted {
+            operation_id,
+            kind: OperationKind::Import,
+            namespace: ns.to_string(),
+            status: OperationStatus::Running,
+        }),
+    )
+        .into_response())
 }
 
 /// Explicit compaction.

--- a/crates/firnflow-api/src/handlers.rs
+++ b/crates/firnflow-api/src/handlers.rs
@@ -15,7 +15,7 @@
 //! * `GET    /operations/{operation_id}`
 //! * `GET    /metrics`
 
-use std::io::{BufReader, Write};
+use std::io::BufReader;
 use std::sync::Arc;
 
 use arrow_array::RecordBatchReader;
@@ -28,6 +28,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
 
 use firnflow_core::{
     decode_list_cursor, validate_arrow_import_schema, FirnflowError, IndexRequest, ListOrder,
@@ -514,11 +515,17 @@ pub async fn import(
     // Spool the body to disk so the Lance write/commit can run in the
     // background after a fast 202, and so memory stays bounded. The
     // route bypasses the global body limit, so the import-specific byte
-    // cap is the guard against filling the spool disk.
-    let mut tmp = tempfile::Builder::new()
+    // cap is the guard against filling the spool disk. Writes go through
+    // `tokio::fs` (the blocking pool) rather than blocking a runtime
+    // worker on disk for the duration of a multi-GB upload.
+    let tmp = tempfile::Builder::new()
         .prefix("firnflow-import-")
         .tempfile_in(&state.import_tmp_dir)
         .map_err(|e| FirnflowError::Backend(format!("import: create temp file: {e}")))?;
+    let mut writer = tokio::fs::File::from_std(
+        tmp.reopen()
+            .map_err(|e| FirnflowError::Backend(format!("import: open spool file: {e}")))?,
+    );
     let cap = state.import_max_bytes;
     let mut written: u64 = 0;
     let mut stream = body.into_data_stream();
@@ -532,11 +539,18 @@ pub async fn import(
                 format!("import body exceeds FIRNFLOW_IMPORT_MAX_BYTES ({cap} bytes)"),
             ));
         }
-        tmp.write_all(&chunk)
+        writer
+            .write_all(&chunk)
+            .await
             .map_err(|e| FirnflowError::Backend(format!("import: spool write: {e}")))?;
     }
-    tmp.flush()
+    writer
+        .flush()
+        .await
         .map_err(|e| FirnflowError::Backend(format!("import: spool flush: {e}")))?;
+    // Drop the async writer's fd before re-reading the file below; the
+    // bytes are already visible to a fresh handle on the same host.
+    drop(writer);
 
     // Validate the Arrow schema up front so a bad request is a 400
     // before any background work starts (the schema is the first IPC

--- a/crates/firnflow-api/src/lib.rs
+++ b/crates/firnflow-api/src/lib.rs
@@ -79,7 +79,15 @@ pub fn router(state: AppState) -> Router {
         .route("/ns/{namespace}", get(handlers::info))
         // Background-operation status. Read-tier: the opaque operation
         // id is the capability, and warmup (read-tier) creates one too.
-        .route("/operations/{operation_id}", get(handlers::get_operation));
+        .route("/operations/{operation_id}", get(handlers::get_operation))
+        // Bulk Arrow import: streams its (binary) body past the global
+        // body limit, so disable `DefaultBodyLimit` on just this route.
+        // The handler enforces `FIRNFLOW_IMPORT_MAX_BYTES` instead.
+        .merge(
+            Router::new()
+                .route("/ns/{namespace}/import", post(handlers::import))
+                .layer(DefaultBodyLimit::disable()),
+        );
     // ServiceBuilder applies layers top-to-bottom: auth first
     // (attaches the Principal extension), principal limiter second
     // (reads it). `axum::Router::layer` then mounts the whole stack

--- a/crates/firnflow-api/src/operations.rs
+++ b/crates/firnflow-api/src/operations.rs
@@ -45,6 +45,8 @@ pub enum OperationKind {
     ScalarIndex,
     /// Compaction (`POST /ns/{ns}/compact`).
     Compact,
+    /// Bulk Arrow import (`POST /ns/{ns}/import`).
+    Import,
 }
 
 /// Lifecycle state of a tracked operation. See the module docs for why

--- a/crates/firnflow-api/src/state.rs
+++ b/crates/firnflow-api/src/state.rs
@@ -1,5 +1,6 @@
 //! Axum application state.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -45,6 +46,13 @@ pub struct AppState {
     /// once at build time and installs a single global
     /// `DefaultBodyLimit` layer; it is not consulted per request.
     pub max_body_bytes: usize,
+    /// Cap on a single `/import` Arrow body (spooled to disk). `0`
+    /// disables the cap; otherwise the handler returns `413` once the
+    /// streamed body exceeds it. The `/import` route bypasses
+    /// `max_body_bytes`, so this is its replacement guard.
+    pub import_max_bytes: u64,
+    /// Directory the `/import` handler spools request bodies to.
+    pub import_tmp_dir: PathBuf,
 }
 
 impl AppState {
@@ -142,6 +150,8 @@ pub async fn build_state(cfg: &AppConfig) -> anyhow::Result<AppState> {
         auth: Arc::new(auth),
         rate_limit: cfg.rate_limit.clone(),
         max_body_bytes: cfg.max_body_bytes,
+        import_max_bytes: cfg.import_max_bytes,
+        import_tmp_dir: cfg.import_tmp_dir.clone(),
     })
 }
 

--- a/crates/firnflow-api/tests/api_auth.rs
+++ b/crates/firnflow-api/tests/api_auth.rs
@@ -261,6 +261,8 @@ async fn secret_debug_does_not_leak_in_app_config() {
         object_cache_dir: std::env::temp_dir(),
         object_cache_bytes: 0,
         object_cache_max_entry_bytes: 0,
+        import_max_bytes: 0,
+        import_tmp_dir: std::env::temp_dir(),
     };
     let dbg = format!("{:?}", cfg);
     assert!(
@@ -321,6 +323,8 @@ async fn duplicate_keys_fail_startup_before_cache_setup() {
         object_cache_dir: std::env::temp_dir(),
         object_cache_bytes: 0,
         object_cache_max_entry_bytes: 0,
+        import_max_bytes: 0,
+        import_tmp_dir: std::env::temp_dir(),
     };
 
     let err = match build_state(&cfg).await {

--- a/crates/firnflow-api/tests/api_import.rs
+++ b/crates/firnflow-api/tests/api_import.rs
@@ -1,0 +1,231 @@
+//! Integration tests for `POST /ns/{namespace}/import` — the binary
+//! Arrow IPC bulk-ingest path.
+//!
+//! Offline tests (no MinIO) cover the synchronous rejections that fire
+//! before any storage is touched: wrong `Content-Type` (415), a body
+//! over `FIRNFLOW_IMPORT_MAX_BYTES` (413), and a malformed Arrow stream
+//! (400). The MinIO-gated test drives a real Arrow IPC body end to end:
+//! 202 + `operation_id`, poll to `succeeded`, then confirm the rows
+//! landed in a single commit.
+//!
+//! ```text
+//! docker compose up -d minio minio-init
+//! ./scripts/cargo test -p firnflow-api --test api_import -- --ignored
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+use arrow_array::{RecordBatch, UInt64Array};
+use arrow_ipc::writer::StreamWriter;
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use firnflow_api::router;
+use serde_json::Value;
+use tower::ServiceExt;
+
+mod common;
+use common::{test_state, test_state_offline, unique_namespace};
+
+const ARROW_CT: &str = "application/vnd.apache.arrow.stream";
+const DIM: usize = 4;
+
+async fn post_bytes(
+    app: axum::Router,
+    uri: String,
+    content_type: &str,
+    body: Vec<u8>,
+) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+async fn get(app: axum::Router, uri: String) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, json)
+}
+
+fn single_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::UInt64, false),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            false,
+        ),
+    ]))
+}
+
+fn single_batch(schema: &SchemaRef, ids: &[u64]) -> RecordBatch {
+    let id_arr = UInt64Array::from_iter_values(ids.iter().copied());
+    let mut list = FixedSizeListBuilder::new(Float32Builder::new(), DIM as i32);
+    for &id in ids {
+        for axis in 0..DIM {
+            list.values().append_value(if axis == (id as usize % DIM) {
+                1.0
+            } else {
+                0.0
+            });
+        }
+        list.append(true);
+    }
+    RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id_arr), Arc::new(list.finish())],
+    )
+    .unwrap()
+}
+
+/// Serialize batches as an Arrow IPC stream (the `/import` wire format).
+fn arrow_ipc(schema: &SchemaRef, batches: &[RecordBatch]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut w = StreamWriter::try_new(&mut buf, schema).unwrap();
+        for b in batches {
+            w.write(b).unwrap();
+        }
+        w.finish().unwrap();
+    }
+    buf
+}
+
+#[tokio::test]
+async fn import_rejects_wrong_content_type() {
+    let (state, _tmp) = test_state_offline().await;
+    let app = router(state);
+    let ns = unique_namespace("import-ct");
+    let (status, _) = post_bytes(
+        app,
+        format!("/ns/{ns}/import"),
+        "application/json",
+        b"{}".to_vec(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        "non-Arrow content type must be rejected with 415"
+    );
+}
+
+#[tokio::test]
+async fn import_rejects_body_over_cap() {
+    let (mut state, _tmp) = test_state_offline().await;
+    state.import_max_bytes = 16; // tiny cap for the test
+    let app = router(state);
+    let ns = unique_namespace("import-413");
+    // 100 bytes > 16-byte cap; the cap trips during spooling, before any
+    // schema parse or storage touch, so the bytes need not be valid Arrow.
+    let (status, _) = post_bytes(app, format!("/ns/{ns}/import"), ARROW_CT, vec![0u8; 100]).await;
+    assert_eq!(
+        status,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "a body over FIRNFLOW_IMPORT_MAX_BYTES must be rejected with 413"
+    );
+}
+
+#[tokio::test]
+async fn import_rejects_malformed_arrow() {
+    let (state, _tmp) = test_state_offline().await;
+    let app = router(state);
+    let ns = unique_namespace("import-garbage");
+    let (status, _) = post_bytes(
+        app,
+        format!("/ns/{ns}/import"),
+        ARROW_CT,
+        b"this is not an arrow stream".to_vec(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a body that is not a valid Arrow IPC stream must be rejected with 400"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_arrow_stream_lands_in_one_commit() {
+    let (state, _tmp) = test_state().await;
+    let app = router(state);
+    let ns = unique_namespace("import-ok");
+    let schema = single_schema();
+
+    // Two batches in one stream → must be a single commit (table version 1
+    // on a fresh namespace = the lone append, since the empty create is
+    // version-zero state until the first data lands... assert <= 2 either
+    // way, then confirm via row_count below).
+    let body = arrow_ipc(
+        &schema,
+        &[
+            single_batch(&schema, &[0, 1, 2, 3]),
+            single_batch(&schema, &[4, 5, 6, 7]),
+        ],
+    );
+    let (status, accepted) =
+        post_bytes(app.clone(), format!("/ns/{ns}/import"), ARROW_CT, body).await;
+    assert_eq!(
+        status,
+        StatusCode::ACCEPTED,
+        "import returns 202: {accepted}"
+    );
+    let op_id = accepted["operation_id"]
+        .as_str()
+        .expect("202 carries operation_id")
+        .to_string();
+    assert_eq!(accepted["kind"], "import");
+
+    // Poll the operation to completion.
+    let mut succeeded = false;
+    for _ in 0..600 {
+        let (s, op) = get(app.clone(), format!("/operations/{op_id}")).await;
+        assert_eq!(s, StatusCode::OK);
+        match op["status"].as_str() {
+            Some("succeeded") => {
+                succeeded = true;
+                break;
+            }
+            Some("failed") => panic!("import operation failed: {op}"),
+            _ => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    }
+    assert!(succeeded, "import operation did not finish in time");
+
+    let (s, info) = get(app, format!("/ns/{ns}")).await;
+    assert_eq!(s, StatusCode::OK, "namespace info: {info}");
+    assert_eq!(
+        info["row_count"].as_u64().unwrap(),
+        8,
+        "all 8 rows imported"
+    );
+}

--- a/crates/firnflow-api/tests/common/mod.rs
+++ b/crates/firnflow-api/tests/common/mod.rs
@@ -102,6 +102,8 @@ pub async fn test_state_with_auth(
         auth: Arc::new(auth),
         rate_limit,
         max_body_bytes: 32 * 1024 * 1024,
+        import_max_bytes: 0,
+        import_tmp_dir: tmp.path().to_path_buf(),
     };
     (state, tmp)
 }
@@ -163,6 +165,8 @@ pub async fn test_state_offline_with_auth(
         auth: Arc::new(auth),
         rate_limit,
         max_body_bytes: 32 * 1024 * 1024,
+        import_max_bytes: 0,
+        import_tmp_dir: tmp.path().to_path_buf(),
     };
     (state, tmp)
 }
@@ -187,6 +191,8 @@ pub fn dummy_config() -> AppConfig {
         object_cache_dir: std::env::temp_dir(),
         object_cache_bytes: 0,
         object_cache_max_entry_bytes: 0,
+        import_max_bytes: 0,
+        import_tmp_dir: std::env::temp_dir(),
     }
 }
 

--- a/crates/firnflow-core/src/lib.rs
+++ b/crates/firnflow-core/src/lib.rs
@@ -20,8 +20,8 @@ pub mod vector;
 
 pub use error::FirnflowError;
 pub use manager::{
-    decode_list_cursor, encode_list_cursor, validate_scalar_index_column, CompactResult,
-    NamespaceManager, UpsertRow, LIST_MAX_LIMIT,
+    decode_list_cursor, encode_list_cursor, validate_arrow_import_schema,
+    validate_scalar_index_column, CompactResult, NamespaceManager, UpsertRow, LIST_MAX_LIMIT,
 };
 pub use metrics::CoreMetrics;
 pub use namespace::NamespaceId;

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -1792,6 +1792,20 @@ pub fn validate_arrow_import_schema(
         None => false,
     };
 
+    // Reject unknown columns so a misspelled name (or stray data the
+    // server would otherwise silently drop) is a clear 400. Only `id`,
+    // one of `vector`/`vectors`, and `text` are read.
+    const ALLOWED: &[&str] = &["id", "vector", "vectors", "text"];
+    for field in schema.fields() {
+        if !ALLOWED.contains(&field.name().as_str()) {
+            return Err(FirnflowError::InvalidRequest(format!(
+                "import: unexpected column `{}`; allowed columns are `id`, \
+                 one of `vector`/`vectors`, and optional `text`",
+                field.name()
+            )));
+        }
+    }
+
     Ok((kind, dim, has_text))
 }
 
@@ -1843,20 +1857,62 @@ impl IngestReader {
             ));
         }
 
-        // Multivector rows must carry at least one sub-vector; an empty
-        // list would have no MaxSim contribution and the JSON path never
-        // produces one.
-        if matches!(self.kind, VectorKind::Multivector) {
-            let list = vector.as_any().downcast_ref::<ListArray>().ok_or_else(|| {
-                ArrowError::InvalidArgumentError("import: `vectors` is not a List array".into())
-            })?;
-            let offsets = list.value_offsets();
-            if offsets.windows(2).any(|w| w[1] - w[0] == 0) {
-                return Err(ArrowError::InvalidArgumentError(
-                    "import: a row has an empty `vectors` list (multivector rows need at \
-                     least one sub-vector)"
-                        .into(),
-                ));
+        // Reject nulls anywhere inside the vector payload, not just at the
+        // top level. A valid Arrow `FixedSizeList<Float32>` can carry a
+        // non-null row with null float children, and a multivector input
+        // can carry null inner sub-vectors or null floats — none of which
+        // the JSON `/upsert` path can produce, so `/import` rejects them
+        // too. (`FixedSizeList` makes the per-vector width structural, so
+        // there is no separate dim check.)
+        match self.kind {
+            VectorKind::Single => {
+                let fsl = vector
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        ArrowError::InvalidArgumentError(
+                            "import: `vector` is not a FixedSizeList array".into(),
+                        )
+                    })?;
+                if fsl.values().null_count() != 0 {
+                    return Err(ArrowError::InvalidArgumentError(
+                        "import: `vector` contains null float values".into(),
+                    ));
+                }
+            }
+            VectorKind::Multivector => {
+                let list = vector.as_any().downcast_ref::<ListArray>().ok_or_else(|| {
+                    ArrowError::InvalidArgumentError("import: `vectors` is not a List array".into())
+                })?;
+                // Each row needs at least one sub-vector (an empty list has
+                // no MaxSim contribution; the JSON path never makes one).
+                let offsets = list.value_offsets();
+                if offsets.windows(2).any(|w| w[1] - w[0] == 0) {
+                    return Err(ArrowError::InvalidArgumentError(
+                        "import: a row has an empty `vectors` list (multivector rows need at \
+                         least one sub-vector)"
+                            .into(),
+                    ));
+                }
+                let inner = list.values();
+                if inner.null_count() != 0 {
+                    return Err(ArrowError::InvalidArgumentError(
+                        "import: `vectors` contains null sub-vectors".into(),
+                    ));
+                }
+                let inner_fsl = inner
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        ArrowError::InvalidArgumentError(
+                            "import: `vectors` inner is not a FixedSizeList array".into(),
+                        )
+                    })?;
+                if inner_fsl.values().null_count() != 0 {
+                    return Err(ArrowError::InvalidArgumentError(
+                        "import: `vectors` contains null float values".into(),
+                    ));
+                }
             }
         }
 
@@ -2337,6 +2393,12 @@ mod tests {
                 Field::new("id", DataType::UInt64, false),
                 Field::new("vector", single_vec.clone(), false),
                 Field::new("text", DataType::Int32, true),
+            ]),
+            // unknown/extra column (e.g. a misspelled name)
+            Schema::new(vec![
+                Field::new("id", DataType::UInt64, false),
+                Field::new("vector", single_vec.clone(), false),
+                Field::new("vectr", single_vec.clone(), false),
             ]),
         ];
         for (i, s) in rejected.iter().enumerate() {

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -1794,14 +1794,22 @@ pub fn validate_arrow_import_schema(
 
     // Reject unknown columns so a misspelled name (or stray data the
     // server would otherwise silently drop) is a clear 400. Only `id`,
-    // one of `vector`/`vectors`, and `text` are read.
+    // one of `vector`/`vectors`, and `text` are read. Arrow permits
+    // duplicate field names and column lookup returns the first match,
+    // so a repeated column would silently shadow data — reject those too.
     const ALLOWED: &[&str] = &["id", "vector", "vectors", "text"];
+    let mut seen = HashSet::new();
     for field in schema.fields() {
-        if !ALLOWED.contains(&field.name().as_str()) {
+        let name = field.name().as_str();
+        if !ALLOWED.contains(&name) {
             return Err(FirnflowError::InvalidRequest(format!(
-                "import: unexpected column `{}`; allowed columns are `id`, \
-                 one of `vector`/`vectors`, and optional `text`",
-                field.name()
+                "import: unexpected column `{name}`; allowed columns are `id`, \
+                 one of `vector`/`vectors`, and optional `text`"
+            )));
+        }
+        if !seen.insert(name) {
+            return Err(FirnflowError::InvalidRequest(format!(
+                "import: duplicate column `{name}`; each column may appear at most once"
             )));
         }
     }
@@ -2399,6 +2407,13 @@ mod tests {
                 Field::new("id", DataType::UInt64, false),
                 Field::new("vector", single_vec.clone(), false),
                 Field::new("vectr", single_vec.clone(), false),
+            ]),
+            // duplicate column name (Arrow allows it; we reject it so the
+            // second does not silently shadow the first)
+            Schema::new(vec![
+                Field::new("id", DataType::UInt64, false),
+                Field::new("vector", single_vec.clone(), false),
+                Field::new("vector", single_vec.clone(), false),
             ]),
         ];
         for (i, s) in rejected.iter().enumerate() {

--- a/crates/firnflow-core/src/manager.rs
+++ b/crates/firnflow-core/src/manager.rs
@@ -34,23 +34,25 @@
 //! reads on that same handle.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use arrow_array::builder::{FixedSizeListBuilder, Float32Builder, ListBuilder, StringBuilder};
 use arrow_array::{
-    Array, ArrayRef, FixedSizeListArray, Float32Array, ListArray, RecordBatch, RecordBatchIterator,
-    RecordBatchReader, StringArray, TimestampMicrosecondArray, UInt64Array,
+    new_null_array, Array, ArrayRef, FixedSizeListArray, Float32Array, ListArray, RecordBatch,
+    RecordBatchIterator, RecordBatchReader, StringArray, TimestampMicrosecondArray, UInt64Array,
 };
-use arrow_schema::{DataType, Field, Schema, TimeUnit};
+use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef, TimeUnit};
 use dashmap::DashMap;
 use futures::{StreamExt, TryStreamExt};
 use lance::dataset::scanner::ColumnOrdering;
+use lance::dataset::{WriteMode, WriteParams};
 use lancedb::index::scalar::{BTreeIndexBuilder, FtsIndexBuilder, FullTextSearchQuery};
 use lancedb::index::vector::IvfPqIndexBuilder;
 use lancedb::index::{Index, IndexType};
 use lancedb::query::{ExecutableQuery, QueryBase, Select};
-use lancedb::table::OptimizeAction;
+use lancedb::table::{OptimizeAction, WriteOptions};
 use lancedb::DistanceType;
 use object_store::aws::AmazonS3Builder;
 use object_store::gcp::GoogleCloudStorageBuilder;
@@ -700,6 +702,110 @@ impl NamespaceManager {
             .await
             .map_err(|e| FirnflowError::Backend(format!("build id index: {e}")))?;
         Ok(())
+    }
+
+    /// Bulk-append the rows from an Arrow IPC stream, insert-only, in a
+    /// single Lance commit.
+    ///
+    /// This is the binary bulk-ingest path behind `POST /ns/{ns}/import`.
+    /// Unlike [`upsert`](Self::upsert) it does **not** merge by `id`: the
+    /// caller asserts the ids are new, so there is no per-batch match
+    /// scan, and the whole stream is written as one append commit
+    /// (`WriteMode::Append`, `skip_auto_cleanup`) regardless of how many
+    /// Arrow batches it carries — `Table::add` pulls the wrapped reader
+    /// one batch at a time, so peak memory stays at a single batch.
+    ///
+    /// The incoming schema is validated up front
+    /// ([`validate_arrow_import_schema`]); each batch is then validated
+    /// row-by-row (non-null `id`, non-null vector payload, non-empty
+    /// multivector lists) and projected into the canonical table schema
+    /// with a server-set `_ingested_at`. On a fresh namespace the
+    /// stream's kind/dim fix the namespace; on an existing one they must
+    /// match. No `id` index is built (this path never does a merge
+    /// lookup — build indexes after the load, per the large-ingest
+    /// recipe). Returns the number of rows appended.
+    pub async fn import_arrow(
+        &self,
+        ns: &NamespaceId,
+        reader: Box<dyn RecordBatchReader + Send>,
+    ) -> Result<usize, FirnflowError> {
+        let in_schema = reader.schema();
+        let (kind, dim, has_text) = validate_arrow_import_schema(&in_schema)?;
+
+        // Fresh namespace: the stream fixes kind/dim. Existing: it must
+        // match the established shape.
+        let info = match self.resolve_schema_info(ns).await? {
+            Some(info) => {
+                if info.kind != kind || info.dim != dim {
+                    return Err(FirnflowError::InvalidRequest(format!(
+                        "import: stream is {} dim {dim}, but namespace {ns} is {} dim {}",
+                        kind.as_label(),
+                        info.kind.as_label(),
+                        info.dim,
+                    )));
+                }
+                info
+            }
+            None => NamespaceSchemaInfo {
+                dim,
+                kind,
+                has_ingested_at: true,
+            },
+        };
+
+        let tbl = self.get_or_open_table(ns, info.kind, info.dim).await?;
+        let canonical = Self::schema_for_kind(info.kind, info.dim, true);
+
+        // Column positions in the incoming stream (any order).
+        let id_idx = in_schema
+            .index_of("id")
+            .map_err(|e| FirnflowError::InvalidRequest(format!("import: {e}")))?;
+        let vec_name = match info.kind {
+            VectorKind::Single => "vector",
+            VectorKind::Multivector => "vectors",
+        };
+        let vec_idx = in_schema
+            .index_of(vec_name)
+            .map_err(|e| FirnflowError::InvalidRequest(format!("import: {e}")))?;
+        let text_idx = if has_text {
+            in_schema.index_of("text").ok()
+        } else {
+            None
+        };
+
+        let rows = Arc::new(AtomicU64::new(0));
+        let ingest = IngestReader {
+            inner: reader,
+            canonical: canonical.clone(),
+            kind: info.kind,
+            id_idx,
+            vec_idx,
+            text_idx,
+            ts_micros: current_micros(),
+            rows: Arc::clone(&rows),
+        };
+
+        // One append commit for the whole stream. `WriteParams::default()`
+        // is `Create`, so `Append` must be set explicitly;
+        // `skip_auto_cleanup` drops the per-commit old-version cleanup that
+        // adds up under high-frequency ingest (run compaction as explicit
+        // maintenance instead).
+        let write_params = WriteParams {
+            mode: WriteMode::Append,
+            skip_auto_cleanup: true,
+            ..Default::default()
+        };
+        let ingest: Box<dyn RecordBatchReader + Send> = Box::new(ingest);
+        tbl.add(ingest)
+            .write_options(WriteOptions {
+                lance_write_params: Some(write_params),
+            })
+            .execute()
+            .await
+            .map_err(map_import_lance_error)?;
+
+        self.schema_info.insert(ns.clone(), info);
+        Ok(rows.load(Ordering::Relaxed) as usize)
     }
 
     /// Remove every object under a namespace prefix from the
@@ -1553,6 +1659,240 @@ fn current_micros() -> i64 {
 /// both vector fields, has both fields populated, has an empty
 /// inner-vector list on a multivector payload, or has mixed
 /// sub-vector dimensions within a multivector payload.
+/// Extract the dimension of a `FixedSizeList<Float32, dim>` data type,
+/// ignoring child-field naming. Returns `None` for any other type.
+fn fixed_size_float_dim(dt: &DataType) -> Option<usize> {
+    match dt {
+        DataType::FixedSizeList(field, size) if field.data_type() == &DataType::Float32 => {
+            Some(*size as usize)
+        }
+        _ => None,
+    }
+}
+
+/// Extract the inner dimension of a `List<FixedSizeList<Float32, dim>>`
+/// (the multivector payload type). Returns `None` for any other type.
+fn list_of_fixed_size_float_dim(dt: &DataType) -> Option<usize> {
+    match dt {
+        DataType::List(field) => fixed_size_float_dim(field.data_type()),
+        _ => None,
+    }
+}
+
+/// Validate the Arrow schema of a `/import` stream and report the
+/// namespace kind, vector dimension, and whether a `text` column is
+/// present.
+///
+/// The stream must carry `id` (`UInt64`) plus exactly one vector
+/// payload column, mirroring the JSON field names: `vector`
+/// (`FixedSizeList<Float32, dim>`, single-vector) or `vectors`
+/// (`List<FixedSizeList<Float32, dim>>`, multivector). An optional
+/// `text` column must be `Utf8`. The server owns `_ingested_at`, so it
+/// must **not** be supplied. The vector column's element type must
+/// match Firn's canonical shape exactly (child field `item`, `Float32`)
+/// so Lance appends it without a cast.
+///
+/// Returns [`FirnflowError::InvalidRequest`] for any missing, extra, or
+/// mistyped column, letting the API layer answer `400` before it starts
+/// the background import.
+pub fn validate_arrow_import_schema(
+    schema: &Schema,
+) -> Result<(VectorKind, usize, bool), FirnflowError> {
+    match schema.column_with_name("id") {
+        Some((_, f)) if f.data_type() == &DataType::UInt64 => {}
+        Some((_, f)) => {
+            return Err(FirnflowError::InvalidRequest(format!(
+                "import: column `id` must be UInt64, got {:?}",
+                f.data_type()
+            )));
+        }
+        None => {
+            return Err(FirnflowError::InvalidRequest(
+                "import: required column `id` (UInt64) is missing".into(),
+            ));
+        }
+    }
+
+    if schema.column_with_name(INGESTED_AT_COLUMN).is_some() {
+        return Err(FirnflowError::InvalidRequest(format!(
+            "import: column `{INGESTED_AT_COLUMN}` is server-owned and must not be included"
+        )));
+    }
+
+    let has_vector = schema.column_with_name("vector").is_some();
+    let has_vectors = schema.column_with_name("vectors").is_some();
+    let (kind, dim) = match (has_vector, has_vectors) {
+        (true, true) => {
+            return Err(FirnflowError::InvalidRequest(
+                "import: set exactly one of `vector` or `vectors`, not both".into(),
+            ));
+        }
+        (false, false) => {
+            return Err(FirnflowError::InvalidRequest(
+                "import: missing vector payload (column `vector` for single-vector \
+                 or `vectors` for multivector namespaces)"
+                    .into(),
+            ));
+        }
+        (true, false) => {
+            let (_, f) = schema.column_with_name("vector").expect("checked present");
+            let dim = fixed_size_float_dim(f.data_type()).ok_or_else(|| {
+                FirnflowError::InvalidRequest(format!(
+                    "import: column `vector` must be FixedSizeList<Float32, dim>, got {:?}",
+                    f.data_type()
+                ))
+            })?;
+            (VectorKind::Single, dim)
+        }
+        (false, true) => {
+            let (_, f) = schema.column_with_name("vectors").expect("checked present");
+            let dim = list_of_fixed_size_float_dim(f.data_type()).ok_or_else(|| {
+                FirnflowError::InvalidRequest(format!(
+                    "import: column `vectors` must be List<FixedSizeList<Float32, dim>>, got {:?}",
+                    f.data_type()
+                ))
+            })?;
+            (VectorKind::Multivector, dim)
+        }
+    };
+
+    if dim == 0 {
+        return Err(FirnflowError::InvalidRequest(
+            "import: vector dimension must be non-zero".into(),
+        ));
+    }
+
+    // Require the exact canonical element type (child field `item`,
+    // Float32, nullable) so `Table::add` accepts the column without a
+    // cast. The dim probes above are lenient on child naming; this is
+    // the strict gate.
+    let canonical = NamespaceManager::schema_for_kind(kind, dim, false);
+    let canonical_vec = canonical.field(1).data_type();
+    let vec_name = match kind {
+        VectorKind::Single => "vector",
+        VectorKind::Multivector => "vectors",
+    };
+    let (_, f) = schema.column_with_name(vec_name).expect("checked present");
+    if f.data_type() != canonical_vec {
+        return Err(FirnflowError::InvalidRequest(format!(
+            "import: column `{vec_name}` must be {canonical_vec:?} \
+             (Float32 elements, child field `item`), got {:?}",
+            f.data_type()
+        )));
+    }
+
+    let has_text = match schema.column_with_name("text") {
+        Some((_, f)) if f.data_type() == &DataType::Utf8 => true,
+        Some((_, f)) => {
+            return Err(FirnflowError::InvalidRequest(format!(
+                "import: column `text` must be Utf8, got {:?}",
+                f.data_type()
+            )));
+        }
+        None => false,
+    };
+
+    Ok((kind, dim, has_text))
+}
+
+/// Classify a `Table::add` failure: an Arrow error means the client's
+/// stream was malformed or a row failed validation (the
+/// [`IngestReader`] surfaces row-level rejections as `ArrowError`), so
+/// it maps to a caller-facing `InvalidRequest`; anything else is a
+/// backend (S3 / commit) failure.
+fn map_import_lance_error(e: lancedb::Error) -> FirnflowError {
+    match e {
+        lancedb::Error::Arrow { .. } => {
+            FirnflowError::InvalidRequest(format!("import: malformed Arrow data: {e}"))
+        }
+        other => FirnflowError::Backend(format!("table.add: {other}")),
+    }
+}
+
+/// Adapts a client `/import` Arrow stream into Firn's canonical table
+/// schema. For each batch it validates the rows, appends a server-set
+/// `_ingested_at`, and emits a batch matching `schema_for_kind`. Handed
+/// to `Table::add`, which pulls one batch at a time, so the whole
+/// stream lands in a single commit with peak memory of one batch.
+struct IngestReader {
+    inner: Box<dyn RecordBatchReader + Send>,
+    canonical: SchemaRef,
+    kind: VectorKind,
+    id_idx: usize,
+    vec_idx: usize,
+    text_idx: Option<usize>,
+    ts_micros: i64,
+    rows: Arc<AtomicU64>,
+}
+
+impl IngestReader {
+    fn project(&self, batch: &RecordBatch) -> Result<RecordBatch, ArrowError> {
+        let n = batch.num_rows();
+
+        let id = batch.column(self.id_idx).clone();
+        if id.null_count() != 0 {
+            return Err(ArrowError::InvalidArgumentError(
+                "import: column `id` contains null values".into(),
+            ));
+        }
+
+        let vector = batch.column(self.vec_idx).clone();
+        if vector.null_count() != 0 {
+            return Err(ArrowError::InvalidArgumentError(
+                "import: vector payload contains null rows".into(),
+            ));
+        }
+
+        // Multivector rows must carry at least one sub-vector; an empty
+        // list would have no MaxSim contribution and the JSON path never
+        // produces one.
+        if matches!(self.kind, VectorKind::Multivector) {
+            let list = vector.as_any().downcast_ref::<ListArray>().ok_or_else(|| {
+                ArrowError::InvalidArgumentError("import: `vectors` is not a List array".into())
+            })?;
+            let offsets = list.value_offsets();
+            if offsets.windows(2).any(|w| w[1] - w[0] == 0) {
+                return Err(ArrowError::InvalidArgumentError(
+                    "import: a row has an empty `vectors` list (multivector rows need at \
+                     least one sub-vector)"
+                        .into(),
+                ));
+            }
+        }
+
+        let text: ArrayRef = match self.text_idx {
+            Some(i) => batch.column(i).clone(),
+            None => new_null_array(&DataType::Utf8, n),
+        };
+
+        let ts: ArrayRef = Arc::new(TimestampMicrosecondArray::from_iter_values(
+            std::iter::repeat_n(self.ts_micros, n),
+        ));
+
+        let out = RecordBatch::try_new(self.canonical.clone(), vec![id, vector, text, ts])?;
+        self.rows.fetch_add(n as u64, Ordering::Relaxed);
+        Ok(out)
+    }
+}
+
+impl Iterator for IngestReader {
+    type Item = Result<RecordBatch, ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.next() {
+            Some(Ok(batch)) => Some(self.project(&batch)),
+            Some(Err(e)) => Some(Err(e)),
+            None => None,
+        }
+    }
+}
+
+impl RecordBatchReader for IngestReader {
+    fn schema(&self) -> SchemaRef {
+        self.canonical.clone()
+    }
+}
+
 fn inspect_row_payload(row: &UpsertRow) -> Result<(VectorKind, usize), FirnflowError> {
     let single_set = !row.vector.is_empty();
     let multi_set = row.vectors.as_ref().map(|v| !v.is_empty()).unwrap_or(false);
@@ -1924,6 +2264,90 @@ mod tests {
             validate_scalar_index_column("text"),
             Err(FirnflowError::InvalidRequest(_))
         ));
+    }
+
+    #[test]
+    fn import_schema_validation() {
+        let single_vec = NamespaceManager::schema_for_kind(VectorKind::Single, 4, false)
+            .field(1)
+            .data_type()
+            .clone();
+        let multi_vec = NamespaceManager::schema_for_kind(VectorKind::Multivector, 4, false)
+            .field(1)
+            .data_type()
+            .clone();
+
+        // Happy: single-vector, no text.
+        let s = Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("vector", single_vec.clone(), false),
+        ]);
+        assert_eq!(
+            validate_arrow_import_schema(&s).unwrap(),
+            (VectorKind::Single, 4, false)
+        );
+
+        // Happy: multivector with text.
+        let s = Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("vectors", multi_vec.clone(), false),
+            Field::new("text", DataType::Utf8, true),
+        ]);
+        assert_eq!(
+            validate_arrow_import_schema(&s).unwrap(),
+            (VectorKind::Multivector, 4, true)
+        );
+
+        // Each of these must be rejected as InvalidRequest.
+        let bad_float =
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), 4);
+        let rejected = [
+            // missing id
+            Schema::new(vec![Field::new("vector", single_vec.clone(), false)]),
+            // wrong id type
+            Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("vector", single_vec.clone(), false),
+            ]),
+            // server-owned _ingested_at supplied
+            Schema::new(vec![
+                Field::new("id", DataType::UInt64, false),
+                Field::new("vector", single_vec.clone(), false),
+                Field::new(
+                    INGESTED_AT_COLUMN,
+                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    false,
+                ),
+            ]),
+            // neither vector nor vectors
+            Schema::new(vec![Field::new("id", DataType::UInt64, false)]),
+            // both vector and vectors
+            Schema::new(vec![
+                Field::new("id", DataType::UInt64, false),
+                Field::new("vector", single_vec.clone(), false),
+                Field::new("vectors", multi_vec.clone(), false),
+            ]),
+            // wrong element type (Float64)
+            Schema::new(vec![
+                Field::new("id", DataType::UInt64, false),
+                Field::new("vector", bad_float, false),
+            ]),
+            // text wrong type
+            Schema::new(vec![
+                Field::new("id", DataType::UInt64, false),
+                Field::new("vector", single_vec.clone(), false),
+                Field::new("text", DataType::Int32, true),
+            ]),
+        ];
+        for (i, s) in rejected.iter().enumerate() {
+            assert!(
+                matches!(
+                    validate_arrow_import_schema(s),
+                    Err(FirnflowError::InvalidRequest(_))
+                ),
+                "schema #{i} should have been rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/firnflow-core/src/service.rs
+++ b/crates/firnflow-core/src/service.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use arrow_array::RecordBatchReader;
 use bincode::config;
 use serde::Serialize;
 
@@ -143,6 +144,28 @@ impl NamespaceService {
         self.semantic.invalidate(ns);
         self.metrics.record_write(ns, start.elapsed().as_secs_f64());
         Ok(())
+    }
+
+    /// Bulk-append an Arrow IPC stream insert-only, in a single commit
+    /// (the binary `/import` path). Cache handling matches
+    /// [`upsert`](Self::upsert): the append advances the table version,
+    /// so results cached against the pre-import version become
+    /// unreachable with no explicit bump, and the semantic sidecar is
+    /// cleared eagerly. Returns the number of rows appended.
+    ///
+    /// Records `s3_requests_total{operation="import"}` eagerly and
+    /// `write_duration_seconds` on return.
+    pub async fn import(
+        &self,
+        ns: &NamespaceId,
+        reader: Box<dyn RecordBatchReader + Send>,
+    ) -> Result<usize, FirnflowError> {
+        let start = Instant::now();
+        self.metrics.record_s3_request(ns, "import");
+        let imported = self.manager.import_arrow(ns, reader).await?;
+        self.semantic.invalidate(ns);
+        self.metrics.record_write(ns, start.elapsed().as_secs_f64());
+        Ok(imported)
     }
 
     /// Delete every object under the namespace prefix.

--- a/crates/firnflow-core/tests/manager_import.rs
+++ b/crates/firnflow-core/tests/manager_import.rs
@@ -9,8 +9,9 @@
 //! 2. A multi-batch stream lands in **one** Lance commit (the table
 //!    version advances by exactly 1), i.e. no per-batch commit
 //!    amplification — the whole point of the feature.
-//! 3. Row-level validation rejects null ids and empty multivector rows
-//!    as `InvalidRequest`.
+//! 3. Row-level validation rejects null ids, null float values inside a
+//!    vector or sub-vector, and empty multivector rows as
+//!    `InvalidRequest`.
 //!
 //! Gated `#[ignore]`: needs MinIO up.
 //!
@@ -317,6 +318,75 @@ async fn import_rejects_empty_multivector_row() {
         .import_arrow(&ns, reader(schema, vec![batch]))
         .await
         .expect_err("empty multivector row must be rejected");
+    assert!(
+        matches!(err, FirnflowError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_rejects_null_float_in_single_vector() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("import-nullfloat")).unwrap();
+    let schema = single_schema();
+
+    // Two non-null rows; the second carries a null float child value,
+    // which a `FixedSizeList<Float32>` allows but the JSON path can't make.
+    let id_arr = UInt64Array::from_iter_values([1u64, 2]);
+    let mut list = FixedSizeListBuilder::new(Float32Builder::new(), DIM as i32);
+    for _ in 0..DIM {
+        list.values().append_value(0.0);
+    }
+    list.append(true);
+    list.values().append_null();
+    for _ in 1..DIM {
+        list.values().append_value(0.0);
+    }
+    list.append(true);
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id_arr), Arc::new(list.finish())],
+    )
+    .unwrap();
+
+    let err = mgr
+        .import_arrow(&ns, reader(schema, vec![batch]))
+        .await
+        .expect_err("null float in a vector must be rejected");
+    assert!(
+        matches!(err, FirnflowError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_rejects_null_float_in_multivector() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("import-mvnullfloat")).unwrap();
+    let schema = multi_schema();
+
+    // One row, one sub-vector whose first float is null.
+    let id_arr = UInt64Array::from_iter_values([1u64]);
+    let inner = FixedSizeListBuilder::new(Float32Builder::new(), DIM as i32);
+    let mut outer = ListBuilder::new(inner);
+    outer.values().values().append_null();
+    for _ in 1..DIM {
+        outer.values().values().append_value(0.0);
+    }
+    outer.values().append(true);
+    outer.append(true);
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id_arr), Arc::new(outer.finish())],
+    )
+    .unwrap();
+
+    let err = mgr
+        .import_arrow(&ns, reader(schema, vec![batch]))
+        .await
+        .expect_err("null float in a sub-vector must be rejected");
     assert!(
         matches!(err, FirnflowError::InvalidRequest(_)),
         "expected InvalidRequest, got {err:?}"

--- a/crates/firnflow-core/tests/manager_import.rs
+++ b/crates/firnflow-core/tests/manager_import.rs
@@ -1,0 +1,324 @@
+//! Integration tests for the binary bulk-import path
+//! (`NamespaceManager::import_arrow`, behind `POST /ns/{ns}/import`).
+//!
+//! These prove the behaviour the JSON `/upsert` path can't give a
+//! large first load:
+//!
+//! 1. An Arrow stream appends insert-only and the rows are queryable,
+//!    for both single-vector and multivector namespaces.
+//! 2. A multi-batch stream lands in **one** Lance commit (the table
+//!    version advances by exactly 1), i.e. no per-batch commit
+//!    amplification — the whole point of the feature.
+//! 3. Row-level validation rejects null ids and empty multivector rows
+//!    as `InvalidRequest`.
+//!
+//! Gated `#[ignore]`: needs MinIO up.
+//!
+//! ```text
+//! docker compose up -d minio minio-init
+//! ./scripts/cargo test -p firnflow-core --test manager_import \
+//!     -- --ignored --nocapture
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::builder::{FixedSizeListBuilder, Float32Builder, ListBuilder};
+use arrow_array::{RecordBatch, RecordBatchIterator, RecordBatchReader, UInt64Array};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use firnflow_core::metrics::test_metrics;
+use firnflow_core::{FirnflowError, NamespaceId, NamespaceManager, StorageRoot};
+
+const DIM: usize = 8;
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn unique_namespace(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}-{nanos}")
+}
+
+fn minio_options() -> HashMap<String, String> {
+    HashMap::from([
+        (
+            "aws_access_key_id".into(),
+            env_or("FIRNFLOW_S3_ACCESS_KEY", "minioadmin"),
+        ),
+        (
+            "aws_secret_access_key".into(),
+            env_or("FIRNFLOW_S3_SECRET_KEY", "minioadmin"),
+        ),
+        (
+            "aws_endpoint".into(),
+            env_or("FIRNFLOW_S3_ENDPOINT", "http://127.0.0.1:9000"),
+        ),
+        ("aws_region".into(), "us-east-1".into()),
+        ("allow_http".into(), "true".into()),
+        ("aws_virtual_hosted_style_request".into(), "false".into()),
+    ])
+}
+
+fn manager() -> NamespaceManager {
+    let bucket = env_or("FIRNFLOW_S3_BUCKET", "firnflow-test");
+    NamespaceManager::new(
+        StorageRoot::s3_bucket(&bucket).unwrap(),
+        minio_options(),
+        test_metrics(),
+    )
+}
+
+fn float32_item() -> Arc<Field> {
+    Arc::new(Field::new("item", DataType::Float32, true))
+}
+
+fn single_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::UInt64, false),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(float32_item(), DIM as i32),
+            false,
+        ),
+    ]))
+}
+
+fn multi_schema() -> SchemaRef {
+    let inner = DataType::FixedSizeList(float32_item(), DIM as i32);
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::UInt64, false),
+        Field::new(
+            "vectors",
+            DataType::List(Arc::new(Field::new("item", inner, true))),
+            false,
+        ),
+    ]))
+}
+
+/// A single-vector batch: each id gets a unit vector on axis `id % DIM`.
+fn single_batch(schema: &SchemaRef, ids: &[u64]) -> RecordBatch {
+    let id_arr = UInt64Array::from_iter_values(ids.iter().copied());
+    let mut list = FixedSizeListBuilder::new(Float32Builder::new(), DIM as i32);
+    for &id in ids {
+        for axis in 0..DIM {
+            list.values().append_value(if axis == (id as usize % DIM) {
+                1.0
+            } else {
+                0.0
+            });
+        }
+        list.append(true);
+    }
+    RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id_arr), Arc::new(list.finish())],
+    )
+    .unwrap()
+}
+
+/// A multivector batch: each id gets `subs` sub-vectors.
+fn multi_batch(schema: &SchemaRef, ids: &[u64], subs: usize) -> RecordBatch {
+    let id_arr = UInt64Array::from_iter_values(ids.iter().copied());
+    let inner = FixedSizeListBuilder::new(Float32Builder::new(), DIM as i32);
+    let mut outer = ListBuilder::new(inner);
+    for _ in ids {
+        for s in 0..subs {
+            for axis in 0..DIM {
+                outer
+                    .values()
+                    .values()
+                    .append_value(if axis == s % DIM { 1.0 } else { 0.0 });
+            }
+            outer.values().append(true);
+        }
+        outer.append(true);
+    }
+    RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id_arr), Arc::new(outer.finish())],
+    )
+    .unwrap()
+}
+
+fn reader(schema: SchemaRef, batches: Vec<RecordBatch>) -> Box<dyn RecordBatchReader + Send> {
+    Box::new(RecordBatchIterator::new(
+        batches.into_iter().map(Ok),
+        schema,
+    ))
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_single_vector_is_queryable() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("import-single")).unwrap();
+    let schema = single_schema();
+
+    let batches = vec![
+        single_batch(&schema, &[0, 1, 2, 3]),
+        single_batch(&schema, &[4, 5, 6, 7]),
+    ];
+    let imported = mgr
+        .import_arrow(&ns, reader(schema, batches))
+        .await
+        .expect("import");
+    assert_eq!(imported, 8, "all rows across both batches appended");
+
+    let info = mgr.info(&ns).await.unwrap().expect("namespace exists");
+    assert_eq!(info.row_count, 8);
+
+    // _ingested_at is server-set on import, so a query carries it back.
+    let mut q = vec![0.0_f32; DIM];
+    q[0] = 1.0;
+    let results = mgr
+        .query(&ns, q, None, 10, None, None, true)
+        .await
+        .expect("query")
+        .results;
+    assert!(!results.is_empty(), "imported rows are searchable");
+    assert!(
+        results.iter().all(|r| r.ingested_at_micros.is_some()),
+        "import stamps _ingested_at"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_multibatch_is_a_single_commit() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("import-onecommit")).unwrap();
+    let schema = single_schema();
+
+    // Seed the namespace (creates the table + one append commit).
+    mgr.import_arrow(
+        &ns,
+        reader(schema.clone(), vec![single_batch(&schema, &[0, 1])]),
+    )
+    .await
+    .expect("seed import");
+    let before = mgr.info(&ns).await.unwrap().unwrap();
+
+    // A second import carrying FOUR batches must advance the table
+    // version by exactly 1 — proving the whole stream is one commit, not
+    // one-commit-per-batch (the commit-amplification the feature fixes).
+    let four = vec![
+        single_batch(&schema, &[2, 3]),
+        single_batch(&schema, &[4, 5]),
+        single_batch(&schema, &[6, 7]),
+        single_batch(&schema, &[8, 9]),
+    ];
+    let imported = mgr
+        .import_arrow(&ns, reader(schema, four))
+        .await
+        .expect("multi-batch import");
+    assert_eq!(imported, 8);
+
+    let after = mgr.info(&ns).await.unwrap().unwrap();
+    assert_eq!(
+        after.table_version,
+        before.table_version + 1,
+        "a 4-batch import must be exactly one commit (version +1), got {} -> {}",
+        before.table_version,
+        after.table_version
+    );
+    assert_eq!(after.row_count, 10, "2 seeded + 8 imported");
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_multivector_is_queryable() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("import-multi")).unwrap();
+    let schema = multi_schema();
+
+    let imported = mgr
+        .import_arrow(
+            &ns,
+            reader(schema.clone(), vec![multi_batch(&schema, &[0, 1, 2], 3)]),
+        )
+        .await
+        .expect("multivector import");
+    assert_eq!(imported, 3);
+
+    let info = mgr.info(&ns).await.unwrap().unwrap();
+    assert_eq!(info.row_count, 3);
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_rejects_null_id() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("import-nullid")).unwrap();
+
+    // id column is nullable here so the batch builds; the row-level
+    // check inside the import must still reject the null.
+    let schema: SchemaRef = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::UInt64, true),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(float32_item(), DIM as i32),
+            false,
+        ),
+    ]));
+    let id_arr = UInt64Array::from(vec![Some(1u64), None]);
+    let mut list = FixedSizeListBuilder::new(Float32Builder::new(), DIM as i32);
+    for _ in 0..2 {
+        for _ in 0..DIM {
+            list.values().append_value(0.0);
+        }
+        list.append(true);
+    }
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id_arr), Arc::new(list.finish())],
+    )
+    .unwrap();
+
+    let err = mgr
+        .import_arrow(&ns, reader(schema, vec![batch]))
+        .await
+        .expect_err("null id must be rejected");
+    assert!(
+        matches!(err, FirnflowError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn import_rejects_empty_multivector_row() {
+    let mgr = manager();
+    let ns = NamespaceId::new(unique_namespace("import-emptymv")).unwrap();
+    let schema = multi_schema();
+
+    // Two ids; the second row has zero sub-vectors (empty list).
+    let id_arr = UInt64Array::from_iter_values([1u64, 2]);
+    let inner = FixedSizeListBuilder::new(Float32Builder::new(), DIM as i32);
+    let mut outer = ListBuilder::new(inner);
+    // row 1: one sub-vector.
+    for _ in 0..DIM {
+        outer.values().values().append_value(0.0);
+    }
+    outer.values().append(true);
+    outer.append(true);
+    // row 2: empty.
+    outer.append(true);
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(id_arr), Arc::new(outer.finish())],
+    )
+    .unwrap();
+
+    let err = mgr
+        .import_arrow(&ns, reader(schema, vec![batch]))
+        .await
+        .expect_err("empty multivector row must be rejected");
+    assert!(
+        matches!(err, FirnflowError::InvalidRequest(_)),
+        "expected InvalidRequest, got {err:?}"
+    );
+}

--- a/docs/api.html
+++ b/docs/api.html
@@ -194,6 +194,7 @@
           <li>exactly one of <code>vector</code> (<code>FixedSizeList&lt;Float32, dim&gt;</code>, single-vector) or <code>vectors</code> (<code>List&lt;FixedSizeList&lt;Float32, dim&gt;&gt;</code>, multivector). The <code>FixedSizeList</code> child field must be named <code>item</code> (the default for e.g. PyArrow).</li>
           <li>optional <code>text</code> — <code>Utf8</code>.</li>
           <li><code>_ingested_at</code> must <strong>not</strong> be present; the server sets it.</li>
+          <li>any other column is rejected — a misspelled name is a <code>400</code>, not silently dropped. Vector floats must be non-null (no null child values inside a vector or sub-vector), and multivector rows must have at least one sub-vector.</li>
         </ul>
         <p>On a fresh namespace the stream fixes the vector kind and dimension; on an existing one they must match. Schema problems are rejected with <code>400</code> before any work starts; row-level problems (null <code>id</code>, empty multivector row) and a truncated/malformed stream surface as a <strong>failed operation</strong> after the <code>202</code>.</p>
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -176,6 +176,51 @@
       </div>
     </div>
 
+    <!-- POST /ns/{ns}/import -->
+    <div class="endpoint">
+      <div class="endpoint-header" aria-expanded="true">
+        <span class="method method-post">POST</span>
+        <span class="endpoint-path">/ns/{namespace}/import</span>
+        <span class="endpoint-desc">Bulk-ingest an Arrow IPC stream (binary, insert-only, async)</span>
+      </div>
+      <div class="endpoint-body">
+        <p>The bulk first-load path. The body is an <a href="https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format">Arrow IPC stream</a>, not JSON: binary and columnar, so embeddings avoid JSON's ~3x decimal-text inflation, and the route is not bound by <code>FIRNFLOW_MAX_BODY_BYTES</code> (a whole corpus can stream in one request). The entire stream is appended in a <strong>single Lance commit</strong>, which is what keeps throughput flat on a large load where many small <code>/upsert</code> commits would not.</p>
+        <p><strong>Insert-only.</strong> Rows are appended, not merged: a repeated <code>id</code> creates a second row. Use <code>/import</code> for first-loads or known-new ids, and <code>/upsert</code> for idempotent updates. Build indexes <em>after</em> the load (see the README "Loading data at scale" recipe).</p>
+
+        <h4>Request</h4>
+        <p><code>Content-Type: application/vnd.apache.arrow.stream</code> (<code>application/octet-stream</code> is also accepted). The stream's Arrow schema must carry:</p>
+        <ul>
+          <li><code>id</code> — <code>UInt64</code>, non-null.</li>
+          <li>exactly one of <code>vector</code> (<code>FixedSizeList&lt;Float32, dim&gt;</code>, single-vector) or <code>vectors</code> (<code>List&lt;FixedSizeList&lt;Float32, dim&gt;&gt;</code>, multivector). The <code>FixedSizeList</code> child field must be named <code>item</code> (the default for e.g. PyArrow).</li>
+          <li>optional <code>text</code> — <code>Utf8</code>.</li>
+          <li><code>_ingested_at</code> must <strong>not</strong> be present; the server sets it.</li>
+        </ul>
+        <p>On a fresh namespace the stream fixes the vector kind and dimension; on an existing one they must match. Schema problems are rejected with <code>400</code> before any work starts; row-level problems (null <code>id</code>, empty multivector row) and a truncated/malformed stream surface as a <strong>failed operation</strong> after the <code>202</code>.</p>
+
+        <h4>Response (202)</h4>
+        <pre><code>{
+  "operation_id": "op_018f3a2b-7c4d-7e1f-9abc-1234567890ab",
+  "kind": "import",
+  "namespace": "demo",
+  "status": "running"
+}</code></pre>
+        <p>Poll <code>GET /operations/{operation_id}</code> for completion. Tuning: <code>FIRNFLOW_IMPORT_MAX_BYTES</code> caps a single import body spooled to disk (default 8 GiB; <code>0</code> disables, returns <code>413</code> when exceeded), and <code>FIRNFLOW_IMPORT_TMP_DIR</code> sets the spool directory.</p>
+
+        <h4>Example</h4>
+        <pre><code># write an Arrow IPC stream file (e.g. with pyarrow's RecordBatchStreamWriter), then:
+curl -X POST http://localhost:3000/ns/demo/import \
+     -H 'Content-Type: application/vnd.apache.arrow.stream' \
+     --data-binary @rows.arrows</code></pre>
+
+        <h4>Errors</h4>
+        <ul>
+          <li><code>400</code> — body is not a valid Arrow IPC stream, or the schema is missing/extra/mistyped (see Request)</li>
+          <li><code>413</code> — body exceeds <code>FIRNFLOW_IMPORT_MAX_BYTES</code></li>
+          <li><code>415</code> — wrong <code>Content-Type</code></li>
+        </ul>
+      </div>
+    </div>
+
     <!-- POST /ns/{ns}/query -->
     <div class="endpoint">
       <div class="endpoint-header" aria-expanded="true">


### PR DESCRIPTION
## Summary

Add `POST /ns/{namespace}/import`, a binary bulk-ingest path for large first loads. The body is an Arrow IPC stream rather than JSON, so embeddings carry no decimal-text inflation (JSON encodes each `f32` as ~10+ bytes of text against 4 bytes binary), the route is not bound by `FIRNFLOW_MAX_BODY_BYTES`, and the whole stream is appended in a single Lance commit. It is insert-only and returns `202` with an `operation_id`; poll `GET /operations/{id}` for completion.

Two env vars tune it: `FIRNFLOW_IMPORT_MAX_BYTES` (default 8 GiB; `0` disables the cap) and `FIRNFLOW_IMPORT_TMP_DIR` (default the system temp dir).

## Behavior notes

The motivation is large S3-backed first loads. On the JSON `/upsert` path each call is a separate Lance commit, so commit and small-fragment bookkeeping grows as the namespace fills and throughput decays the larger the corpus gets, and JSON's float inflation runs into the body limit on top of that. `/import` removes both costs: one commit for the whole stream, a binary columnar wire, and the body streamed past the limit. A multi-batch stream advancing the table version by exactly 1 is asserted in a test, which is the property that proves the commit amplification is gone.

The append uses `WriteMode::Append` with `skip_auto_cleanup` (old-version cleanup moves to explicit compaction). It is insert-only by `id`: a repeated `id` makes a second row, so this is for first loads or known-new ids, not idempotent updates. Use `/upsert` for those. Cache handling matches `/upsert`: the semantic sidecar is cleared eagerly and the exact result cache rides the table-version generation that the append advances, so no separate invalidation step is needed.

The schema gate is strict and rejects bad input before any work starts. The stream must carry `id` (`UInt64`), exactly one of `vector` (`FixedSizeList<Float32, dim>`) or `vectors` (`List<FixedSizeList<Float32, dim>>`) with the canonical element type (child field `item`), and an optional `text` (`Utf8`). `_ingested_at` is server-set and must not be present. Unknown columns, duplicate column names, null ids, null float values nested inside a vector or sub-vector, and empty multivector rows are all rejected. Schema problems are a synchronous `400` (wrong content type is `415`, an over-cap body is `413`); row-level and stream-decode failures after the `202` surface as a failed operation.

The handler spools the request body to disk through `tokio::fs` (so a multi-GB upload does not pin a runtime worker on blocking writes), enforces the byte cap while streaming, validates the schema, then runs the append in the background. It does not auto-build the `id` index (this path never does a merge lookup); build indexes after the load, per the large-ingest recipe in the README. The S3-pointer variant, where the caller pre-uploads to object storage and the server ingests object to object, stays a follow-up that reuses this same ingest core.

## Tests

~~~text
./scripts/cargo fmt --all -- --check
./scripts/cargo clippy -p firnflow-core -p firnflow-api --all-targets -j 1 -- -D warnings
./scripts/cargo test -p firnflow-core --lib import_schema_validation -j 1
./scripts/cargo test -p firnflow-api --test api_import -j 1 \
    -- import_rejects_wrong_content_type import_rejects_body_over_cap import_rejects_malformed_arrow

# MinIO up (docker compose up -d minio minio-init):
./scripts/cargo test -p firnflow-core --test manager_import -j 1 -- --ignored
./scripts/cargo test -p firnflow-api --test api_import -j 1 -- --ignored

# manager_import covers: single + multivector queryable, a 4-batch stream
# is exactly one commit (version +1), append across two imports, and the
# rejections (null id, null nested float single + multivector, empty
# multivector row). api_import covers the 415/413/400 paths offline and a
# real Arrow body end to end (202 -> poll -> row count).
~~~

`cargo test --workspace` was deliberately skipped on this branch: the parallel link of every workspace and integration-test binary against Lance is too heavy for this dev host (16 GB RAM, disk-tight `target/`). The suites above were run against the local docker-compose MinIO stack; the BEIR-scale S3 ingest that #77's "done when" calls for has not been run here.

Refs #77.
