### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-06-19
+
 ### Added
 - `POST /ns/{namespace}/import` bulk-ingests an Arrow IPC stream. It is the binary, columnar path for large first loads: the body is an Arrow IPC stream rather than JSON, so embeddings avoid JSON's ~3x decimal-text inflation, the route is not bound by `FIRNFLOW_MAX_BODY_BYTES` (a whole corpus can stream in one request), and the entire stream is appended in a single Lance commit. That last part is the point: on a large load, the per-batch commit and small-fragment bookkeeping of many small `/upsert` calls is what makes throughput decay as a namespace grows, and a single streamed commit removes it. The stream carries `id` (`UInt64`) plus exactly one of `vector` (`FixedSizeList<Float32, dim>`) or `vectors` (`List<FixedSizeList<Float32, dim>>`) and an optional `text` (`Utf8`); `_ingested_at` is server-set. It is **insert-only** (a repeated `id` makes a second row), so it is for first-loads or known-new ids, not idempotent updates — use `/upsert` for those. The handler validates the schema synchronously (`400`/`413`/`415`) then returns `202` with an `operation_id` and runs the append in the background; poll `GET /operations/{operation_id}`. Recommended large-ingest path: import, then compact, then build indexes, then query (documented in the README). Part of the large-ingest work in #77.
 - Two env vars tune `/import`: `FIRNFLOW_IMPORT_MAX_BYTES` caps a single import body spooled to disk (default 8 GiB; `0` disables the cap, exceeding it returns `413`), and `FIRNFLOW_IMPORT_TMP_DIR` sets the spool directory (default the system temp dir).
@@ -220,7 +222,8 @@ development through phases 1 through 8 before being made public;
   benchmark at dim=1536, 100k rows available at
   `bench/results/cold_vs_warm_aws.md`.
 
-[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/gordonmurray/firnflow/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/gordonmurray/firnflow/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/gordonmurray/firnflow/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/gordonmurray/firnflow/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/gordonmurray/firnflow/compare/v0.8.0...v0.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firnflow-api"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-bench"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "firnflow-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cut v0.9.2. Bumps the workspace version to 0.9.2 and finalizes the CHANGELOG for the release.

The release ships the binary Arrow `/import` bulk-ingest endpoint (#80): the body is an Arrow IPC stream rather than JSON, so embeddings avoid JSON's decimal-text inflation, the route is not bound by `FIRNFLOW_MAX_BODY_BYTES`, and the whole stream is appended in a single Lance commit instead of one commit per batch. It is insert-only and returns `202` with an `operation_id`. New env vars `FIRNFLOW_IMPORT_MAX_BYTES` and `FIRNFLOW_IMPORT_TMP_DIR` tune it.

## Behavior notes

- No source changes in this PR beyond the version bump and CHANGELOG; the `/import` code shipped under #80 and was tested there (offline rejections plus the MinIO-backed single-commit, queryability, and validation suites).
- This is a patch release: the new endpoint is additive and changes nothing about the existing routes.
- Tagging `v0.9.2` after this merges triggers `docker-publish.yml`, which publishes `ghcr.io/gordonmurray/firnflow:0.9.2` and moves the `latest` tag.

## Tests

~~~text
./scripts/cargo check -p firnflow-core -p firnflow-api -j 1
~~~

CI runs the full `fmt` / `clippy` / `test` suite on the release branch. `cargo test --workspace` is not run locally on this host (RAM/disk); the `/import` integration suites were exercised against the local MinIO stack under #80.

Refs #77.
